### PR TITLE
Use mktemp so that Julia cleans up time series files

### DIFF
--- a/src/in_memory_time_series_storage.jl
+++ b/src/in_memory_time_series_storage.jl
@@ -109,8 +109,7 @@ end
 
 function convert_to_hdf5(storage::InMemoryTimeSeriesStorage, filename::AbstractString)
     create_file = true
-    preserve_file = true
-    hdf5_storage = Hdf5TimeSeriesStorage(create_file, preserve_file; filename = filename)
+    hdf5_storage = Hdf5TimeSeriesStorage(create_file; filename = filename)
     for record in values(storage.data)
         for pair in record.component_labels
             add_time_series!(hdf5_storage, pair[1], pair[2], record.ts)

--- a/src/time_series_storage.jl
+++ b/src/time_series_storage.jl
@@ -21,7 +21,7 @@ function make_time_series_storage(;
     elseif !isnothing(filename)
         storage = Hdf5TimeSeriesStorage(; filename = filename)
     else
-        storage = Hdf5TimeSeriesStorage(true, false; directory = directory)
+        storage = Hdf5TimeSeriesStorage(true; directory = directory)
     end
 
     return storage

--- a/test/test_hdf5_time_series_storage.jl
+++ b/test/test_hdf5_time_series_storage.jl
@@ -1,9 +1,0 @@
-
-@testset "Test automatic file deletion" begin
-    storage = IS.Hdf5TimeSeriesStorage()
-    filename = storage.file_path
-    @test isfile(filename)
-    storage = nothing
-    GC.gc()
-    @test !isfile(filename)
-end


### PR DESCRIPTION
When I originally wrote this code `mktemp` didn't allow for automatic cleanup.  Now that it does, our code is simpler.  Also, the old code was disobeying a rule that I didn't know about earlier.  You are not supposed to trigger IO in a finalizer. The old code was deleting a file in a finalizer.