### PR TITLE
enable passing abstract type to get component

### DIFF
--- a/src/components.jl
+++ b/src/components.jl
@@ -166,8 +166,8 @@ end
                   name::AbstractString
                  )::Union{T, Nothing} where T <: InfrastructureSystemsType
 
-Get the component of type T with name. Returns nothing if no component matches. If an Abastract
-    Type T is passed the names should be unique accross Abastract Types
+Get the component of type T with name. Returns nothing if no component matches. If T is an abstract
+type then the names of components across all subtypes of T must be unique.
 
 See [`get_components_by_name`](@ref) if the concrete type is unknown.
 

--- a/src/components.jl
+++ b/src/components.jl
@@ -178,7 +178,11 @@ function get_component(
     name::AbstractString,
 )::Union{T, Nothing} where {T <: InfrastructureSystemsType}
     if !isconcretetype(T)
-        throw(ArgumentError("get_component only supports concrete types: $T"))
+        components = get_components(T, components, x -> get_name(x) == name)
+        if length(components) > 1
+            throw(ArgumentError("More than one components of type $T"))
+        end
+        return first(components)
     end
 
     if !haskey(components.data, T)

--- a/src/components.jl
+++ b/src/components.jl
@@ -178,10 +178,7 @@ function get_component(
     name::AbstractString,
 )::Union{T, Nothing} where {T <: InfrastructureSystemsType}
     if !isconcretetype(T)
-        components = get_components(T, components, x -> get_name(x) == name)
-        if length(components) > 1
-            throw(ArgumentError("More than one components of type $T"))
-        end
+        components = get_components_by_name(T, components, name)
         return first(components)
     end
 

--- a/src/components.jl
+++ b/src/components.jl
@@ -182,7 +182,7 @@ function get_component(
     if !isconcretetype(T)
         components = get_components_by_name(T, components, name)
         if length(components) > 1
-            @throw(ArgumentError("More than one abstract component of type $T with name $name in the system. Operation can't continue"))
+            throw(ArgumentError("More than one abstract component of type $T with name $name in the system. Operation can't continue"))
         end
         return isempty(components) ? nothing : first(components)
     end

--- a/src/components.jl
+++ b/src/components.jl
@@ -169,7 +169,7 @@ end
 Get the component of type T with name. Returns nothing if no component matches. If T is an abstract
 type then the names of components across all subtypes of T must be unique.
 
-See [`get_components_by_name`](@ref) if the concrete type is unknown.
+See [`get_components_by_name`](@ref) for abstract types with non-unique names across subtypes.
 
 Throws ArgumentError if T is not a concrete type and there is more than one component with
     requested name

--- a/src/components.jl
+++ b/src/components.jl
@@ -166,11 +166,13 @@ end
                   name::AbstractString
                  )::Union{T, Nothing} where T <: InfrastructureSystemsType
 
-Get the component of concrete type T with name. Returns nothing if no component matches.
+Get the component of type T with name. Returns nothing if no component matches. If an Abastract
+    Type T is passed the names should be unique accross Abastract Types
 
 See [`get_components_by_name`](@ref) if the concrete type is unknown.
 
-Throws ArgumentError if T is not a concrete type.
+Throws ArgumentError if T is not a concrete type and there is more than one component with
+    requested name
 """
 function get_component(
     ::Type{T},
@@ -179,7 +181,10 @@ function get_component(
 )::Union{T, Nothing} where {T <: InfrastructureSystemsType}
     if !isconcretetype(T)
         components = get_components_by_name(T, components, name)
-        return first(components)
+        if length(components) > 1
+            @throw(ArgumentError("More than one abstract component of type $T with name $name in the system. Operation can't continue"))
+        end
+        return isempty(components) ? nothing : first(components)
     end
 
     if !haskey(components.data, T)

--- a/src/utils/test.jl
+++ b/src/utils/test.jl
@@ -13,7 +13,6 @@ struct AdditionalTestComponent <: InfrastructureSystemsType
     internal::InfrastructureSystemsInternal
 end
 
-
 function TestComponent(name, val)
     return TestComponent(name, val, Forecasts(), InfrastructureSystemsInternal())
 end
@@ -21,7 +20,6 @@ end
 function AdditionalTestComponent(name, val)
     return AdditionalTestComponent(name, val, Forecasts(), InfrastructureSystemsInternal())
 end
-
 
 get_val(component::TestComponent) = component.val
 

--- a/src/utils/test.jl
+++ b/src/utils/test.jl
@@ -6,9 +6,22 @@ struct TestComponent <: InfrastructureSystemsType
     internal::InfrastructureSystemsInternal
 end
 
+struct AdditionalTestComponent <: InfrastructureSystemsType
+    name::AbstractString
+    val::Int
+    forecasts::Forecasts
+    internal::InfrastructureSystemsInternal
+end
+
+
 function TestComponent(name, val)
     return TestComponent(name, val, Forecasts(), InfrastructureSystemsInternal())
 end
+
+function AdditionalTestComponent(name, val)
+    return AdditionalTestComponent(name, val, Forecasts(), InfrastructureSystemsInternal())
+end
+
 
 get_val(component::TestComponent) = component.val
 

--- a/test/test_components.jl
+++ b/test/test_components.jl
@@ -113,7 +113,7 @@ end
     @test component.name == "component1"
     @test component.val == 5
 
-    same_name_component = IS.TestComponent("component1", 5)
+    same_name_component = IS.AdditionalTestComponent("component1", 5)
     IS.add_component!(container, same_name_component)
 
     @test_throws ArgumentError IS.get_component(

--- a/test/test_components.jl
+++ b/test/test_components.jl
@@ -113,6 +113,9 @@ end
     @test component.name == "component1"
     @test component.val == 5
 
+    same_name_component = IS.TestComponent("component1", 5)
+    IS.add_component!(container, same_name_component)
+
     @test_throws ArgumentError IS.get_component(
         IS.InfrastructureSystemsType,
         container,


### PR DESCRIPTION
This adds a method to get components by name passing abstract types 