### PR TITLE
Fix serialization of shared time series

### DIFF
--- a/src/hdf5_time_series_storage.jl
+++ b/src/hdf5_time_series_storage.jl
@@ -119,7 +119,7 @@ function add_time_series!(
                 if !HDF5.exists(HDF5.attrs(path), "columns")
                     throw(ArgumentError("columns are specified but existing array does not have columns"))
                 end
-                existing = HDF5.attrs(path)["columns"]
+                existing = Symbol.(HDF5.read(HDF5.attrs(path)["columns"]))
                 if columns != existing
                     throw(ArgumentError("columns do not match $columns $existing"))
                 end

--- a/test/common.jl
+++ b/test/common.jl
@@ -17,6 +17,24 @@ function create_system_data(; with_forecasts = false, time_series_in_memory = fa
     return data
 end
 
+function create_system_data_shared_forecasts(; time_series_in_memory = false)
+    data = IS.SystemData(; time_series_in_memory = time_series_in_memory)
+
+    name1 = "Component1"
+    name2 = "Component2"
+    component1 = IS.TestComponent(name1, 5)
+    component2 = IS.TestComponent(name2, 6)
+    IS.add_component!(data, component1)
+    IS.add_component!(data, component2)
+
+    ts_data = create_time_series_data()
+    forecast = IS.DeterministicInternal("get_val", ts_data)
+    IS.add_forecast!(data, component1, forecast, ts_data)
+    IS.add_forecast!(data, component2, forecast, ts_data)
+
+    return data
+end
+
 function get_all_forecasts(data)
     return collect(IS.iterate_forecasts(data))
 end

--- a/test/test_serialization.jl
+++ b/test/test_serialization.jl
@@ -36,21 +36,21 @@ end
 
 @testset "Test JSON serialization of system data" begin
     for in_memory in (true, false)
-        sys = create_system_data(; with_forecasts = true, time_series_in_memory = in_memory)
+        sys = create_system_data_shared_forecasts(; time_series_in_memory = in_memory)
         _, result = validate_serialization(sys)
         @test result
     end
 end
 
 @testset "Test prepare_for_serialization" begin
-    sys = create_system_data(; with_forecasts = true)
+    sys = create_system_data_shared_forecasts()
     directory = joinpath("dir1", "dir2")
     IS.prepare_for_serialization!(sys, joinpath(directory, "sys.json"))
     @test IS.get_ext(sys.internal)["serialization_directory"] == directory
 end
 
 @testset "Test JSON serialization of with read-only time series" begin
-    sys = create_system_data(; with_forecasts = true, time_series_in_memory = false)
+    sys = create_system_data_shared_forecasts(; time_series_in_memory = false)
     sys2, result = validate_serialization(sys; time_series_read_only = true)
     @test result
     component = collect(IS.get_components(IS.TestComponent, sys2))[1]
@@ -73,7 +73,7 @@ end
 end
 
 @testset "Test JSON serialization of with mutable time series" begin
-    sys = create_system_data(; with_forecasts = true, time_series_in_memory = false)
+    sys = create_system_data_shared_forecasts(; time_series_in_memory = false)
     sys2, result = validate_serialization(sys; time_series_read_only = false)
     @test result
     IS.clear_forecasts!(sys2)


### PR DESCRIPTION
An exception occurred if shared time series data stored in memory were converted to HDF during serialization.

This bug occurs if a PowerSystem is built from RTS data with time_series_in_memory is set to true.  It was introduced in recent changes for PiecewiseFunction forecasts.  Time series data for Areas is shared.