### PR TITLE
delete unused namedtuple_to_dict function

### DIFF
--- a/src/utils/generate_structs.jl
+++ b/src/utils/generate_structs.jl
@@ -206,15 +206,6 @@ function generate_structs(directory, data::Vector; print_results = true)
     end
 end
 
-function namedtuple_to_dict(tuple)
-    parameters = Dict()
-    for property in propertynames(tuple)
-        parameters[string(property)] = getproperty(tuple, property)
-    end
-
-    return parameters
-end
-
 function generate_structs(
     input_file::AbstractString,
     output_directory::AbstractString;


### PR DESCRIPTION
This code appears not to be used from what I can see.