### PR TITLE
Fix printing of undefined components

### DIFF
--- a/src/utils/print.jl
+++ b/src/utils/print.jl
@@ -131,7 +131,7 @@ end
 
 function Base.show(io::IO, ::MIME"text/plain", ists::Vector{<:InfrastructureSystemsType})
     println(io, summary(ists))
-    for i = 1:length(ists)
+    for i in 1:length(ists)
         if isassigned(ists, i)
             println(io, "$(summary(ists[i]))")
         else

--- a/src/utils/print.jl
+++ b/src/utils/print.jl
@@ -131,8 +131,8 @@ end
 
 function Base.show(io::IO, ::MIME"text/plain", ists::Vector{<:InfrastructureSystemsType})
     println(io, summary(ists))
-    for ist in ists
-        println(io, "$(summary(ist))")
+    for i = 1:length(ists)
+        isassigned(ists, i) && println(io, "$(summary(ists[i]))")
     end
 end
 

--- a/src/utils/print.jl
+++ b/src/utils/print.jl
@@ -132,7 +132,11 @@ end
 function Base.show(io::IO, ::MIME"text/plain", ists::Vector{<:InfrastructureSystemsType})
     println(io, summary(ists))
     for i = 1:length(ists)
-        isassigned(ists, i) && println(io, "$(summary(ists[i]))")
+        if isassigned(ists, i)
+            println(io, "$(summary(ists[i]))")
+        else
+            println(io, Base.undef_ref_str)
+        end
     end
 end
 

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -91,6 +91,6 @@ end
 end
 
 @testset "Test undef component prints" begin
-    v = Vector{PowerSystemType}(undef, 3)
-    @test sprint(show, v) == "PowerSystemType[#undef, #undef, #undef]"
+    v = Vector{IS.InfrastructureSystemsType}(undef, 3)
+    @test sprint(show, v) == "InfrastructureSystems.InfrastructureSystemsType[#undef, #undef, #undef]"
 end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -92,5 +92,6 @@ end
 
 @testset "Test undef component prints" begin
     v = Vector{IS.InfrastructureSystemsType}(undef, 3)
-    @test sprint(show, v) == "InfrastructureSystems.InfrastructureSystemsType[#undef, #undef, #undef]"
+    @test sprint(show, v) ==
+          "InfrastructureSystems.InfrastructureSystemsType[#undef, #undef, #undef]"
 end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -89,3 +89,8 @@ end
     @test Fruits.APPLE isa Fruits.Fruit
     @test Fruits.ORANGE isa Fruits.Fruit
 end
+
+@testset "Test undef component prints" begin
+    v = Vector{PowerSystemType}(undef, 3)
+    @test sprint(show, v) == "PowerSystemType[#undef, #undef, #undef]"
+end


### PR DESCRIPTION
Currently, creating a vector of undefined components results in an error:

```
julia> buses = Vector{Bus}(undef, 5)
5-element Array{Bus,1}
Error showing value of type Array{Bus,1}:
ERROR: UndefRefError: access to undefined reference
```

On the other hand, `buses = Vector{Bus}(undef, 5);` works, because the issue is related to `show`. This PR fixes this error:

```
julia> buses = Vector{Bus}(undef, 5)
5-element Array{Bus,1}
#undef
#undef
#undef
#undef
#undef
```