### PR TITLE
Add Deterministic constructors to support all input formats

### DIFF
--- a/src/time_series_parser.jl
+++ b/src/time_series_parser.jl
@@ -224,7 +224,8 @@ function TimeSeriesParsedInfo(metadata::TimeSeriesFileMetadata, ta::TimeSeries.T
             Base.__toplevel__,
             Symbol(metadata.scaling_factor_multiplier_module),
         )
-        multiplier_func = metadata.scaling_factor_multiplier === nothing ? nothing :
+        multiplier_func =
+            metadata.scaling_factor_multiplier === nothing ? nothing :
             getfield(multiplier_mod, Symbol(metadata.scaling_factor_multiplier))
     else
         multiplier_func = nothing

--- a/test/test_time_series.jl
+++ b/test/test_time_series.jl
@@ -99,7 +99,7 @@ end
     for i in 1:len
         component = IS.get_component(IS.TestComponent, sys, string(i))
         ts = IS.get_time_series(IS.Deterministic, component, initial_time, label)
-        hash_ta = hash(get_data(ts))
+        hash_ta = hash(IS.get_data(ts))
         if i == 1
             hash_ta_main = hash_ta
         else


### PR DESCRIPTION
1. Allow user to construct `Deterministic` time series data from a CSV file or DataFrame, and support a normalization factor.
2. Removes `add_time_series!` methods that constructed `Deterministic` and added it to the system in one step. The user will need to perform these steps independently.
3. Adds `add_time_series!` method that supports multiple components.