### PR TITLE
Time series updates

### DIFF
--- a/src/component.jl
+++ b/src/component.jl
@@ -91,7 +91,19 @@ function _check_start_time(start_time, ts_metadata::TimeSeriesMetadata)
 end
 
 """
-Return a time_series for the entire time series range stored for these parameters.
+Return a time series corresponding to the given parameters.
+
+# Arguments
+- `::Type{T}`: Concrete subtype of TimeSeriesData to return
+- `component::InfrastructureSystemsComponent`: Component containing the time series
+- `name::AbstractString`: name of time series
+- `start_time::Union{Nothing, Dates.DateTime} = nothing`: If nothing, use the
+  `initial_timestamp` of the time series. If T is a subtype of Forecast then `start_time`
+  must be a multiple of the forecast interval.
+- `len::Union{Nothing, Int} = nothing`: Length in the time dimension. If nothing, use the
+  entire length.
+- `count::Int = 1`: Only applicable to subtypes of Forecast. Number of forecast windows
+  starting at `start_time` to return.
 """
 function get_time_series(
     ::Type{T},

--- a/src/hdf5_time_series_storage.jl
+++ b/src/hdf5_time_series_storage.jl
@@ -111,6 +111,8 @@ function serialize_time_series!(
             _append_item!(path, "components", component_name)
         end
     end
+
+    return
 end
 
 function _write_time_series_attributes!(

--- a/src/in_memory_time_series_storage.jl
+++ b/src/in_memory_time_series_storage.jl
@@ -52,6 +52,8 @@ function serialize_time_series!(
     else
         add_time_series_reference!(storage, component_uuid, name, uuid)
     end
+
+    return
 end
 
 function add_time_series_reference!(

--- a/src/system_data.jl
+++ b/src/system_data.jl
@@ -110,7 +110,7 @@ function add_time_series_from_file_metadata!(
 ) where {T <: InfrastructureSystemsComponent}
     cache = TimeSeriesCache()
     for metadata in file_metadata
-        if resolution === nothing || metada.resolution == resolution
+        if resolution === nothing || metadata.resolution == resolution
             add_time_series_from_file_metadata_internal!(data, T, cache, metadata)
         end
     end

--- a/src/system_data.jl
+++ b/src/system_data.jl
@@ -84,14 +84,14 @@ Adds time_series from a metadata file or metadata descriptors.
   that includes an array of TimeSeriesFileMetadata instances or a vector.
 - `resolution::DateTime.Period=nothing`: skip time_series that don't match this resolution.
 """
-function add_time_series!(
+function add_time_series_from_file_metadata!(
     data::SystemData,
     ::Type{T},
     metadata_file::AbstractString;
     resolution = nothing,
 ) where {T <: InfrastructureSystemsComponent}
     metadata = read_time_series_file_metadata(metadata_file)
-    return add_time_series!(data, T, metadata; resolution = resolution)
+    return add_time_series_from_file_metadata!(data, T, metadata; resolution = resolution)
 end
 
 """
@@ -102,7 +102,7 @@ Adds time series data from a metadata file or metadata descriptors.
 - `file_metadata::Vector{TimeSeriesFileMetadata}`: metadata for time series
 - `resolution::DateTime.Period=nothing`: skip time_series that don't match this resolution.
 """
-function add_time_series!(
+function add_time_series_from_file_metadata!(
     data::SystemData,
     ::Type{T},
     file_metadata::Vector{TimeSeriesFileMetadata};

--- a/src/system_data.jl
+++ b/src/system_data.jl
@@ -84,14 +84,14 @@ Adds time_series from a metadata file or metadata descriptors.
   that includes an array of TimeSeriesFileMetadata instances or a vector.
 - `resolution::DateTime.Period=nothing`: skip time_series that don't match this resolution.
 """
-function add_time_series_from_file_metadata!(
+function add_time_series!(
     data::SystemData,
     ::Type{T},
     metadata_file::AbstractString;
     resolution = nothing,
 ) where {T <: InfrastructureSystemsComponent}
     metadata = read_time_series_file_metadata(metadata_file)
-    return add_time_series_from_file_metadata!(data, T, metadata; resolution = resolution)
+    return add_time_series!(data, T, metadata; resolution = resolution)
 end
 
 """
@@ -102,7 +102,7 @@ Adds time series data from a metadata file or metadata descriptors.
 - `file_metadata::Vector{TimeSeriesFileMetadata}`: metadata for time series
 - `resolution::DateTime.Period=nothing`: skip time_series that don't match this resolution.
 """
-function add_time_series_from_file_metadata!(
+function add_time_series!(
     data::SystemData,
     ::Type{T},
     file_metadata::Vector{TimeSeriesFileMetadata};
@@ -143,6 +143,7 @@ function add_time_series!(
         time_series;
         skip_if_present = skip_if_present,
     )
+    return
 end
 
 """
@@ -153,7 +154,7 @@ Add the same time series data to multiple components.
 - `components`: iterable of components that will store the same time series reference
 - `time_series::TimeSeriesData`: Any object of subtype TimeSeriesData
 
-This is significantly more efficent than calling add_time_series! for each component
+This is significantly more efficent than calling `add_time_series!` for each component
 individually with the same data because in this case, only one time series array is stored.
 
 Throws ArgumentError if a component is not stored in the system.
@@ -183,6 +184,7 @@ function _attach_time_series_and_serialize!(
         get_name(ts_metadata),
         ts,
     )
+    return
 end
 
 function add_time_series_from_file_metadata_internal!(
@@ -195,6 +197,7 @@ function add_time_series_from_file_metadata_internal!(
     component = file_metadata.component
     time_series = make_time_series!(cache, file_metadata)
     add_time_series!(data, component, time_series)
+    return
 end
 
 """

--- a/test/common.jl
+++ b/test/common.jl
@@ -8,12 +8,7 @@ function create_system_data(; with_time_series = false, time_series_in_memory = 
 
     if with_time_series
         file = joinpath(FORECASTS_DIR, "ComponentsAsColumnsNoTime.json")
-        IS.add_time_series_from_file_metadata!(
-            data,
-            IS.InfrastructureSystemsComponent,
-            file,
-        )
-
+        IS.add_time_series!(data, IS.InfrastructureSystemsComponent, file)
         time_series = get_all_time_series(data)
         @assert length(time_series) > 0
     end

--- a/test/common.jl
+++ b/test/common.jl
@@ -8,7 +8,7 @@ function create_system_data(; with_time_series = false, time_series_in_memory = 
 
     if with_time_series
         file = joinpath(FORECASTS_DIR, "ComponentsAsColumnsNoTime.json")
-        IS.add_time_series!(data, IS.InfrastructureSystemsComponent, file)
+        IS.add_time_series_from_file_metadata!(data, IS.InfrastructureSystemsComponent, file)
         time_series = get_all_time_series(data)
         @assert length(time_series) > 0
     end

--- a/test/common.jl
+++ b/test/common.jl
@@ -8,7 +8,11 @@ function create_system_data(; with_time_series = false, time_series_in_memory = 
 
     if with_time_series
         file = joinpath(FORECASTS_DIR, "ComponentsAsColumnsNoTime.json")
-        IS.add_time_series_from_file_metadata!(data, IS.InfrastructureSystemsComponent, file)
+        IS.add_time_series_from_file_metadata!(
+            data,
+            IS.InfrastructureSystemsComponent,
+            file,
+        )
         time_series = get_all_time_series(data)
         @assert length(time_series) > 0
     end

--- a/test/test_time_series.jl
+++ b/test/test_time_series.jl
@@ -215,7 +215,7 @@ end
     @test !IS.has_time_series(component)
 
     file = joinpath(FORECASTS_DIR, "ComponentsAsColumnsNoTime.json")
-    IS.add_time_series_from_file_metadata!(data, IS.InfrastructureSystemsComponent, file)
+    IS.add_time_series!(data, IS.InfrastructureSystemsComponent, file)
     @test IS.has_time_series(component)
 
     all_time_series = get_all_time_series(data)
@@ -253,7 +253,7 @@ end
     IS.add_component!(data, component)
     @test !IS.has_time_series(component)
     file = joinpath(FORECASTS_DIR, "ForecastPointers.json")
-    IS.add_time_series_from_file_metadata!(data, IS.InfrastructureSystemsComponent, file)
+    IS.add_time_series!(data, IS.InfrastructureSystemsComponent, file)
     @test IS.has_time_series(component)
 
     sys = IS.SystemData()

--- a/test/test_time_series.jl
+++ b/test/test_time_series.jl
@@ -215,7 +215,7 @@ end
     @test !IS.has_time_series(component)
 
     file = joinpath(FORECASTS_DIR, "ComponentsAsColumnsNoTime.json")
-    IS.add_time_series!(data, IS.InfrastructureSystemsComponent, file)
+    IS.add_time_series_from_file_metadata!(data, IS.InfrastructureSystemsComponent, file)
     @test IS.has_time_series(component)
 
     all_time_series = get_all_time_series(data)
@@ -253,7 +253,7 @@ end
     IS.add_component!(data, component)
     @test !IS.has_time_series(component)
     file = joinpath(FORECASTS_DIR, "ForecastPointers.json")
-    IS.add_time_series!(data, IS.InfrastructureSystemsComponent, file)
+    IS.add_time_series_from_file_metadata!(data, IS.InfrastructureSystemsComponent, file)
     @test IS.has_time_series(component)
 
     sys = IS.SystemData()


### PR DESCRIPTION
- Reverts a name change.
- Adds user-appropriate docstring for get_time_series.
- Fixes a recently-introduced parsing bug.
- Removes an inadvertent return that messed up a docstring.