### PR TITLE
Remove internal fields from Base.show

### DIFF
--- a/src/probabilistic.jl
+++ b/src/probabilistic.jl
@@ -31,14 +31,15 @@ function Probabilistic(
     end
     data = handle_normalization_factor(input_data, normalization_factor)
 
-
-    return Probabilistic(name,
-                        initial_timestamp,
-                        horizon,
-                        resolution,
-                        percentiles,
-                        data,
-                        scaling_factor_multiplier)
+    return Probabilistic(
+        name,
+        initial_timestamp,
+        horizon,
+        resolution,
+        percentiles,
+        data,
+        scaling_factor_multiplier,
+    )
 end
 
 """
@@ -81,7 +82,6 @@ function Probabilistic(
     )
 end
 
-
 """
 Construct Deterministic from RawTimeSeries.
 """
@@ -108,14 +108,14 @@ function Probabilistic(
     data::SortedDict{Dates.DateTime, Array},
 )
     return Probabilistic(
-            name = get_name(ts_metadata),
-            percentiled = get_percentiles(ta_metadata),
-            initial_timestamp = first(keys(data)),
-            resolution = get_resolution(ts_metadata),
-            horizon = length(first(values(data))),
-            data = data,
-            scaling_factor_multiplier = get_scaling_factor_multiplier(ts_metadata),
-            internal = InfrastructureSystemsInternal(get_time_series_uuid(ts_metadata)),
+        name = get_name(ts_metadata),
+        percentiled = get_percentiles(ta_metadata),
+        initial_timestamp = first(keys(data)),
+        resolution = get_resolution(ts_metadata),
+        horizon = length(first(values(data))),
+        data = data,
+        scaling_factor_multiplier = get_scaling_factor_multiplier(ts_metadata),
+        internal = InfrastructureSystemsInternal(get_time_series_uuid(ts_metadata)),
     )
 end
 

--- a/src/utils/print.jl
+++ b/src/utils/print.jl
@@ -139,19 +139,23 @@ function Base.show(io::IO, ::MIME"text/plain", ist::InfrastructureSystemsCompone
     end
 end
 
-function Base.show(
-    io::IO,
-    ::MIME"text/plain",
-    ists::Vector{<:InfrastructureSystemsComponent},
-)
-    println(io, summary(ists))
-    for i in 1:length(ists)
-        if isassigned(ists, i)
-            println(io, "$(summary(ists[i]))")
+function Base.show(io::IO, ist::InfrastructureSystemsComponent)
+    print(io, string(nameof(typeof(ist))), "(")
+    is_first = true
+    for (name, field_type) in zip(fieldnames(typeof(ist)), fieldtypes(typeof(ist)))
+        if field_type <: TimeSeriesContainer || field_type <: InfrastructureSystemsInternal
+            continue
         else
-            println(io, Base.undef_ref_str)
+            val = getfield(ist, name)
         end
+        if is_first
+            is_first = false
+        else
+            print(io, ", ")
+        end
+        print(io, val)
     end
+    print(io, ")")
 end
 
 function create_components_df(components::Components)


### PR DESCRIPTION
The goal of this PR is to fix https://github.com/NREL-SIIP/PowerSystems.jl/issues/616.  The code changes include an override of `Base.show` for all subtypes of `InfrastructureSystemsComponent`.  I excluded some internal fields that are of little value to users.  I removed an override of `Base.show` for a vector of components because that shouldn't be needed with this change.  And that overrride was not truncating output.

There can still be a lot of text dumped to the screen when the user calls `get_components(SomeType, system)` (which shows an `Iterators.Flatten`) or calls collect on that result.  Julia should automatically truncate the output in the case of `Iterators.Flatten` and vectors.  The components have a lot of fields, and all of them get printed.  We can discuss eliminating more fields.

@raphaelsaavedra commented in the issue above that he was seeing huge amounts of output when he was printing the output of `get_components`.  When I tested the current code I was seeing truncation occur.  Julia would print a bunch of components then `…` and then a bunch more.  It seemed like a lot of text but it wasn't enough to kill a terminal.  It was printing maybe around 100 components definitely not the thousands that were in my system.  This makes me think that something else was going wrong.  If the issue continues to occur with this new version then we can dig deeper.