### PR TITLE
Minor fixes

### DIFF
--- a/src/abstract_time_series.jl
+++ b/src/abstract_time_series.jl
@@ -25,3 +25,4 @@ abstract type TimeSeriesData <: InfrastructureSystemsComponent end
 # - Base.length
 # - get_resolution
 # - make_time_array
+# - eltype_data

--- a/src/deterministic.jl
+++ b/src/deterministic.jl
@@ -210,6 +210,7 @@ function get_array_for_hdf(forecast::Deterministic)
     return transform_array_for_hdf(forecast.data, data_type)
 end
 
+eltype_data(forecast::Deterministic) = eltype_data_common(forecast)
 get_count(forecast::Deterministic) = get_count_common(forecast)
 get_horizon(forecast::Deterministic) = get_horizon_common(forecast)
 get_initial_times(forecast::Deterministic) = get_initial_times_common(forecast)

--- a/src/deterministic_single_time_series.jl
+++ b/src/deterministic_single_time_series.jl
@@ -1,3 +1,5 @@
+eltype_data(ts::DeterministicSingleTimeSeries) = eltype_data(ts.single_time_series)
+
 function get_array_for_hdf(forecast::DeterministicSingleTimeSeries)
     return get_array_for_hdf(forecast.single_time_series)
 end

--- a/src/forecasts.jl
+++ b/src/forecasts.jl
@@ -16,6 +16,12 @@ abstract type AbstractDeterministic <: Forecast end
 
 # This method requires that the forecast type implement a `get_data` method like
 # Deterministic.
+function eltype_data_common(forecast::Forecast)
+    return eltype(first(values(get_data(forecast))))
+end
+
+# This method requires that the forecast type implement a `get_data` method like
+# Deterministic.
 function get_count_common(forecast)
     return length(get_data(forecast))
 end

--- a/src/hdf5_time_series_storage.jl
+++ b/src/hdf5_time_series_storage.jl
@@ -131,14 +131,6 @@ function get_data_type(ts::TimeSeriesData)
     end
 end
 
-function eltype_data(ts::SingleTimeSeries)
-    return eltype(TimeSeries.values(ts.data))
-end
-
-function eltype_data(ts::TimeSeriesData)
-    return eltype(first(values(ts.data)))
-end
-
 function _write_time_series_attributes!(
     storage::Hdf5TimeSeriesStorage,
     ts::T,

--- a/src/probabilistic.jl
+++ b/src/probabilistic.jl
@@ -150,6 +150,7 @@ function get_horizon(forecast::Probabilistic)
     return size(first(values(get_data(forecast))))[1]
 end
 
+eltype_data(forecast::Probabilistic) = eltype_data_common(forecast)
 get_count(forecast::Probabilistic) = get_count_common(forecast)
 get_initial_times(forecast::Probabilistic) = get_initial_times_common(forecast)
 get_initial_timestamp(forecast::Probabilistic) = get_initial_timestamp_common(forecast)

--- a/src/probabilistic.jl
+++ b/src/probabilistic.jl
@@ -28,7 +28,6 @@ function Probabilistic(
     if quantile_count != length(percentiles)
         throw(ArgumentError("The amount of elements in the data doesn't match the length of the percentiles"))
     end
-    data = handle_normalization_factor(input_data, normalization_factor)
 
     return Probabilistic(name, resolution, percentiles, data, scaling_factor_multiplier)
 end

--- a/src/serialization.jl
+++ b/src/serialization.jl
@@ -1,5 +1,5 @@
 # These will get encoded into each dictionary when a struct is serialized.
-const METADATA_KEY = "__metadata"
+const METADATA_KEY = "__metadata__"
 const TYPE_KEY = "type"
 const MODULE_KEY = "module"
 const PARAMETERS_KEY = "parameters"

--- a/src/single_time_series.jl
+++ b/src/single_time_series.jl
@@ -121,6 +121,8 @@ function SingleTimeSeries(info::TimeSeriesParsedInfo)
     )
 end
 
+eltype_data(ts::SingleTimeSeries) = eltype(TimeSeries.values(ts.data))
+
 get_initial_timestamp(time_series::SingleTimeSeries) =
     TimeSeries.timestamp(get_data(time_series))[1]
 


### PR DESCRIPTION
This mostly just fixes use of `eltype_data` for each subtype of TimeSeriesData.