### PR TITLE
Cb/enable retransform

### DIFF
--- a/src/system_data.jl
+++ b/src/system_data.jl
@@ -311,29 +311,27 @@ function clear_time_series!(data::SystemData)
     reset_info!(data.time_series_params)
 end
 
+"""
+Removes all time series of a particular type from a System.
+
+# Arguments
+- `data::SystemData`: system
+- `type::Type{<:TimeSeriesData}`: Type of time series objects to remove.
+"""
 function remove_time_series!(data::SystemData, ::Type{T}) where T <: TimeSeriesData
     for component in iterate_components_with_time_series(data.components)
         for ts in get_time_series_multiple(component, type = T)
             remove_time_series!(data, typeof(ts), component, get_name(ts))
         end
     end
-end
-#=
-function clear_time_series_transformation!(data::SystemData)
-    for component in iterate_components_with_time_series(data.components)
-        container = get_time_series_container(component)
-        for key in keys(container.data)
-            if key.time_series_type <: ForecastMetadata
-                if remove_time_series_metadata!(component, key.time_series_type, key.name)
-                    error("This should have returned false")
-                end
-            end
-        end
+    counts = get_time_series_counts(data)
+    if counts[2] != 0
+        reset_info!(data.time_series_params)
+    elseif counts[3] !=0
+        reset_info!(data.time_series_params.forecast_params)
     end
-    reset_info!(data.time_series_params.forecast_params)
-    return
 end
-=#
+
 
 """
 Returns an iterator of TimeSeriesData instances attached to the system.

--- a/src/system_data.jl
+++ b/src/system_data.jl
@@ -325,10 +325,12 @@ function remove_time_series!(data::SystemData, ::Type{T}) where {T <: TimeSeries
         end
     end
     counts = get_time_series_counts(data)
-    if counts[2] == 0 # no more time series objects
-        reset_info!(data.time_series_params)
-    elseif counts[3] == 0 # no more forecast objects
-        reset_info!(data.time_series_params.forecast_params)
+    if counts[3] == 0 # no more forecast objects
+        if counts[2] == 0 # no more static time series objects
+            reset_info!(data.time_series_params)
+        else
+            reset_info!(data.time_series_params.forecast_params)
+        end
     end
 end
 

--- a/src/system_data.jl
+++ b/src/system_data.jl
@@ -325,9 +325,9 @@ function remove_time_series!(data::SystemData, ::Type{T}) where {T <: TimeSeries
         end
     end
     counts = get_time_series_counts(data)
-    if counts[2] != 0
+    if counts[2] == 0 # no more time series objects
         reset_info!(data.time_series_params)
-    elseif counts[3] != 0
+    elseif counts[3] == 0 # no more forecast objects
         reset_info!(data.time_series_params.forecast_params)
     end
 end

--- a/src/system_data.jl
+++ b/src/system_data.jl
@@ -311,6 +311,14 @@ function clear_time_series!(data::SystemData)
     reset_info!(data.time_series_params)
 end
 
+function remove_time_series!(data::SystemData, ::Type{T}) where T <: TimeSeriesData
+    for component in iterate_components_with_time_series(data.components)
+        for ts in get_time_series_multiple(component, type = T)
+            remove_time_series!(data, typeof(ts), component, get_name(ts))
+        end
+    end
+end
+#=
 function clear_time_series_transformation!(data::SystemData)
     for component in iterate_components_with_time_series(data.components)
         container = get_time_series_container(component)
@@ -325,6 +333,7 @@ function clear_time_series_transformation!(data::SystemData)
     reset_info!(data.time_series_params.forecast_params)
     return
 end
+=#
 
 """
 Returns an iterator of TimeSeriesData instances attached to the system.
@@ -393,7 +402,7 @@ function transform_single_time_series!(
             )
             check_add_time_series!(data.time_series_params, params)
             !_is_uninitialized(data.time_series_params.forecast_params) &&
-                clear_time_series_transformation!(data)
+                remove_time_series!(data, DeterministicSingleTimeSeries)
         end
 
         transform_single_time_series!(component, T, params)

--- a/src/system_data.jl
+++ b/src/system_data.jl
@@ -318,7 +318,7 @@ Removes all time series of a particular type from a System.
 - `data::SystemData`: system
 - `type::Type{<:TimeSeriesData}`: Type of time series objects to remove.
 """
-function remove_time_series!(data::SystemData, ::Type{T}) where T <: TimeSeriesData
+function remove_time_series!(data::SystemData, ::Type{T}) where {T <: TimeSeriesData}
     for component in iterate_components_with_time_series(data.components)
         for ts in get_time_series_multiple(component, type = T)
             remove_time_series!(data, typeof(ts), component, get_name(ts))
@@ -327,11 +327,10 @@ function remove_time_series!(data::SystemData, ::Type{T}) where T <: TimeSeriesD
     counts = get_time_series_counts(data)
     if counts[2] != 0
         reset_info!(data.time_series_params)
-    elseif counts[3] !=0
+    elseif counts[3] != 0
         reset_info!(data.time_series_params.forecast_params)
     end
 end
-
 
 """
 Returns an iterator of TimeSeriesData instances attached to the system.

--- a/test/test_time_series.jl
+++ b/test/test_time_series.jl
@@ -344,7 +344,7 @@ end
             sys,
             IS.DeterministicSingleTimeSeries,
             horizon,
-            Dates.Hour(1),
+            Dates.Hour(100),
         )
         interval = Dates.Minute(30)
         IS.transform_single_time_series!(
@@ -415,25 +415,39 @@ end
             len = horizon - 1,
         )
         # Already stored.
-        @test_throws ArgumentError IS.transform_single_time_series!(
+        @test IS.transform_single_time_series!(
             sys,
             IS.DeterministicSingleTimeSeries,
             horizon,
             interval,
-        )
-        # Mismatched horizon
+        ) == nothing
+        # Bad horizon
         @test_throws IS.ConflictingInputsError IS.transform_single_time_series!(
             sys,
             IS.DeterministicSingleTimeSeries,
-            7,
+            1000, # horizon is longer than single time series
             interval,
         )
-        # Mismatched interval
+        # Good but different horizon
+        @test IS.transform_single_time_series!(
+            sys,
+            IS.DeterministicSingleTimeSeries,
+            12,
+            interval,
+        ) == nothing
+        # Good but different interval
+        @test IS.transform_single_time_series!(
+            sys,
+            IS.DeterministicSingleTimeSeries,
+            2,
+            Dates.Minute(10),
+        ) == nothing
+        # Bad interval
         @test_throws IS.ConflictingInputsError IS.transform_single_time_series!(
             sys,
             IS.DeterministicSingleTimeSeries,
             horizon,
-            Dates.Hour(2),
+            resolution * (horizon + 1),
         )
         # Ensure that deleting one doesn't delete the other.
         if in_memory

--- a/test/test_time_series.jl
+++ b/test/test_time_series.jl
@@ -449,6 +449,7 @@ end
             horizon,
             resolution * (horizon + 1),
         )
+
         # Ensure that deleting one doesn't delete the other.
         if in_memory
             IS.remove_time_series!(sys, IS.Deterministic, component, name)
@@ -459,6 +460,11 @@ end
             @test IS.get_time_series(IS.Deterministic, component, name) isa
                   IS.DeterministicSingleTimeSeries
         end
+
+        # Ensure that attempted removal of nonexistant types works fine
+        counts = IS.get_time_series_counts(sys)
+        IS.remove_time_series!(sys, IS.Probabilistic)
+        @test counts === IS.get_time_series_counts(sys)
     end
 end
 


### PR DESCRIPTION
This PR addresses an issue where running `transform_single_time_series` more than once fails. The new functionality changes the behavior of some of the negative tests, so they have been adjusted.

There is a related issue of adding a new time_series after `transform_single_time_series` has already been executed. This partially addresses that issue by allowing the user to execute `clear_time_series_transformation!`, then adding the new time series, and then running `transform_single_time_series`. But I can address that more concisely after feedback on this approach.

I believe that @sourabhdalvi, @Nongchao, @ugirumurera, and @andrewrosemberg may all be interested in this.