### PR TITLE
apply removal correctly

### DIFF
--- a/src/system_data.jl
+++ b/src/system_data.jl
@@ -390,6 +390,10 @@ function transform_single_time_series!(
     horizon::Int,
     interval::Dates.Period,
 ) where {T <: DeterministicSingleTimeSeries}
+    @debug data.time_series_params.forecast_params
+    if !is_uninitialized(data.time_series_params.forecast_params)
+        remove_time_series!(data, DeterministicSingleTimeSeries)
+    end
     params = nothing
     for component in iterate_components_with_time_series(data.components)
         if params === nothing
@@ -400,8 +404,6 @@ function transform_single_time_series!(
                 interval,
             )
             check_add_time_series!(data.time_series_params, params)
-            !_is_uninitialized(data.time_series_params.forecast_params) &&
-                remove_time_series!(data, DeterministicSingleTimeSeries)
         end
 
         transform_single_time_series!(component, T, params)

--- a/src/time_series_parameters.jl
+++ b/src/time_series_parameters.jl
@@ -154,8 +154,7 @@ function check_add_time_series!(params::TimeSeriesParameters, other::TimeSeriesP
         params.resolution = other.resolution
     end
 
-    if !is_uninitialized(other.forecast_params) &&
-       is_uninitialized(params.forecast_params)
+    if !is_uninitialized(other.forecast_params) && is_uninitialized(params.forecast_params)
         params.forecast_params.horizon = other.forecast_params.horizon
         params.forecast_params.initial_timestamp = other.forecast_params.initial_timestamp
         params.forecast_params.interval = other.forecast_params.interval

--- a/src/time_series_parameters.jl
+++ b/src/time_series_parameters.jl
@@ -18,7 +18,7 @@ function ForecastParameters(;
     return ForecastParameters(horizon, initial_timestamp, interval, count)
 end
 
-function _is_uninitialized(params::ForecastParameters)
+function is_uninitialized(params::ForecastParameters)
     return params.horizon == UNINITIALIZED_LENGTH &&
            params.initial_timestamp == UNINITIALIZED_DATETIME &&
            params.interval == UNINITIALIZED_PERIOD &&
@@ -101,7 +101,7 @@ function reset_info!(params::TimeSeriesParameters)
     @info "Reset system time series parameters."
 end
 
-function _is_uninitialized(params::TimeSeriesParameters)
+function is_uninitialized(params::TimeSeriesParameters)
     return params.resolution == UNINITIALIZED_PERIOD
 end
 
@@ -121,7 +121,7 @@ function _check_forecast_params(
 )
     params = ts_params.forecast_params
     other = ts_other.forecast_params
-    if _is_uninitialized(params) != _is_uninitialized(other)
+    if is_uninitialized(params) != is_uninitialized(other)
         throw(ConflictingInputsError("forecast parameter mismatch"))
     end
 
@@ -149,13 +149,13 @@ function check_add_time_series!(params::TimeSeriesParameters, ts::TimeSeriesData
 end
 
 function check_add_time_series!(params::TimeSeriesParameters, other::TimeSeriesParameters)
-    if _is_uninitialized(params)
+    if is_uninitialized(params)
         # This is the first time series added.
         params.resolution = other.resolution
     end
 
-    if !_is_uninitialized(other.forecast_params) &&
-       _is_uninitialized(params.forecast_params)
+    if !is_uninitialized(other.forecast_params) &&
+       is_uninitialized(params.forecast_params)
         params.forecast_params.horizon = other.forecast_params.horizon
         params.forecast_params.initial_timestamp = other.forecast_params.initial_timestamp
         params.forecast_params.interval = other.forecast_params.interval
@@ -206,7 +206,7 @@ get_time_series_resolution(params::TimeSeriesParameters) = params.resolution
 
 function get_forecast_total_period(p::TimeSeriesParameters)
     f = p.forecast_params
-    _is_uninitialized(f) && return Dates.Second(0)
+    is_uninitialized(f) && return Dates.Second(0)
     return get_total_period(
         f.initial_timestamp,
         f.count,


### PR DESCRIPTION
Fixes a bug introduced in 77d857c1a2c6639e06b082701c6e4f06439eb796 that removes the data for all time forecast always. 

There is one drawback to this approach. If a second call for transform is made and it has inadequate parameters then the correct transformation that was stored before will be eliminated. 