### PR TITLE
Fix removal of existing forecasts in transform_single_time_series

### DIFF
--- a/src/utils/print.jl
+++ b/src/utils/print.jl
@@ -30,7 +30,7 @@ function Base.show(io::IO, ::MIME"text/plain", components::Components)
     println(io, "==========")
     println(io, "Num components: $num_components")
     if num_components > 0
-        println()
+        println(io)
         show(io, df)
     end
 end

--- a/test/common.jl
+++ b/test/common.jl
@@ -60,3 +60,14 @@ end
 function create_dates(start_time::String, resolution, end_time::String)
     return create_dates(Dates.DateTime(start_time), resolution, Dates.DateTime(end_time))
 end
+
+"""
+Verifies that printing an object doesn't crash, which has happened several times.
+"""
+function verify_show(obj)
+    io = IOBuffer()
+    show(io, "text/plain", obj)
+    val = String(take!(io))
+    @test !isempty(val)
+    return
+end


### PR DESCRIPTION
Fixes #182 in a slightly more complete way than #183. The main fix is the same. This PR addresses some inherent problems when checking forecast additions. There were some cases where adding an invalid forecast resulted in an exception but incorrectly mutated system parameters.

closes #183 