### PR TITLE
Remove package-specific RNG

### DIFF
--- a/src/internal.jl
+++ b/src/internal.jl
@@ -120,5 +120,4 @@ function compare_values(x::InfrastructureSystemsInternal, y::InfrastructureSyste
     return match
 end
 
-_RNG = Random.MersenneTwister()
-make_uuid() = UUIDs.uuid4(_RNG)
+make_uuid() = UUIDs.uuid4()


### PR DESCRIPTION
Fixes #197 

The original fix was intended to workaround UUID clashes in PowerSimulations tests. I tested this with the sim_refactor branch of PowerSimulations and that original issue no longer occurs. Tested with Julia 1.5. We changed the way systems get built (PowerSystemsCaseBuilder), and so perhaps that caused some behavior change.

This change will cause the same sequence of UUIDs to be generated when re-running tests in the same Julia 1.5 session. That is what triggered the original issue. Julia is changing its behavior in 1.6. The function `UUIDs.uuid4` no longer uses the `GLOBAL_RNG`, so that behavior will go away then.

From the Julia source:
```
The default rng used by `uuid4` is not `GLOBAL_RNG` and every invocation of `uuid4()` without
an argument should be expected to return a unique identifier. Importantly, the outputs of
`uuid4` do not repeat even when `Random.seed!(seed)` is called. Currently (as of Julia 1.6),
`uuid4` uses `Random.RandomDevice` as the default rng. However, this is an implementation
detail that may change in the future.

!!! compat "Julia 1.6"
    The output of `uuid4` does not depend on `GLOBAL_RNG` as of Julia 1.6.
```