### PR TITLE
Fix get_time_series_multiple for Deterministic

### DIFF
--- a/src/descriptors/structs.json
+++ b/src/descriptors/structs.json
@@ -39,6 +39,11 @@
           "comment": "length of this time series"
         },
         {
+          "name": "time_series_type",
+          "data_type": "Type{<:AbstractDeterministic}",
+          "comment": "Type of the time series data associated with this metadata."
+        },
+        {
           "name": "scaling_factor_multiplier",
           "data_type": "Union{Nothing, Function}",
           "default": "nothing",

--- a/src/deterministic_metadata.jl
+++ b/src/deterministic_metadata.jl
@@ -7,6 +7,41 @@ function DeterministicMetadata(ts::AbstractDeterministic)
         get_count(ts),
         get_uuid(ts),
         get_horizon(ts),
+        typeof(ts),
         get_scaling_factor_multiplier(ts),
     )
+end
+
+function serialize(::Type{<:T}) where {T <: AbstractDeterministic}
+    # This currently cannot be done for all InfrastructureSystemsTypes.
+    # Some are encoded directly as strings.
+    @debug "serialize" T
+    data = Dict{String, Any}()
+    add_serialization_metadata!(data, T)
+    return data
+end
+
+function deserialize_to_dict(::Type{T}, data::Dict) where {T <: DeterministicMetadata}
+    # This is custom because of time_series_type.
+    # Duplicated from src/serialization.jl
+    vals = Dict{Symbol, Any}()
+    for (field_name, field_type) in zip(fieldnames(T), fieldtypes(T))
+        val = data[string(field_name)]
+        if val isa Dict && haskey(val, METADATA_KEY)
+            metadata = get_serialization_metadata(val)
+            if haskey(metadata, FUNCTION_KEY)
+                vals[field_name] = deserialize(Function, val)
+            else
+                type = get_type_from_serialization_metadata(metadata)
+                if field_name == :time_series_type
+                    vals[field_name] = type
+                else
+                    vals[field_name] = deserialize(type, val)
+                end
+            end
+        else
+            vals[field_name] = deserialize(field_type, val)
+        end
+    end
+    return vals
 end

--- a/src/generated/DeterministicMetadata.jl
+++ b/src/generated/DeterministicMetadata.jl
@@ -10,6 +10,7 @@ This file is auto-generated. Do not edit.
         count::Int
         time_series_uuid::UUIDs.UUID
         horizon::Int
+        time_series_type::Type{<:AbstractDeterministic}
         scaling_factor_multiplier::Union{Nothing, Function}
         internal::InfrastructureSystemsInternal
     end
@@ -24,6 +25,7 @@ A deterministic forecast for a particular data field in a Component.
 - `count::Int`: number of forecast windows
 - `time_series_uuid::UUIDs.UUID`: reference to time series data
 - `horizon::Int`: length of this time series
+- `time_series_type::Type{<:AbstractDeterministic}`: Type of the time series data associated with this metadata.
 - `scaling_factor_multiplier::Union{Nothing, Function}`: Applicable when the time series data are scaling factors. Called on the associated component to convert the values.
 - `internal::InfrastructureSystemsInternal`
 """
@@ -41,17 +43,19 @@ mutable struct DeterministicMetadata <: ForecastMetadata
     time_series_uuid::UUIDs.UUID
     "length of this time series"
     horizon::Int
+    "Type of the time series data associated with this metadata."
+    time_series_type::Type{<:AbstractDeterministic}
     "Applicable when the time series data are scaling factors. Called on the associated component to convert the values."
     scaling_factor_multiplier::Union{Nothing, Function}
     internal::InfrastructureSystemsInternal
 end
 
-function DeterministicMetadata(name, resolution, initial_timestamp, interval, count, time_series_uuid, horizon, scaling_factor_multiplier=nothing, )
-    DeterministicMetadata(name, resolution, initial_timestamp, interval, count, time_series_uuid, horizon, scaling_factor_multiplier, InfrastructureSystemsInternal(), )
+function DeterministicMetadata(name, resolution, initial_timestamp, interval, count, time_series_uuid, horizon, time_series_type, scaling_factor_multiplier=nothing, )
+    DeterministicMetadata(name, resolution, initial_timestamp, interval, count, time_series_uuid, horizon, time_series_type, scaling_factor_multiplier, InfrastructureSystemsInternal(), )
 end
 
-function DeterministicMetadata(; name, resolution, initial_timestamp, interval, count, time_series_uuid, horizon, scaling_factor_multiplier=nothing, internal=InfrastructureSystemsInternal(), )
-    DeterministicMetadata(name, resolution, initial_timestamp, interval, count, time_series_uuid, horizon, scaling_factor_multiplier, internal, )
+function DeterministicMetadata(; name, resolution, initial_timestamp, interval, count, time_series_uuid, horizon, time_series_type, scaling_factor_multiplier=nothing, internal=InfrastructureSystemsInternal(), )
+    DeterministicMetadata(name, resolution, initial_timestamp, interval, count, time_series_uuid, horizon, time_series_type, scaling_factor_multiplier, internal, )
 end
 
 """Get [`DeterministicMetadata`](@ref) `name`."""
@@ -68,6 +72,8 @@ get_count(value::DeterministicMetadata) = value.count
 get_time_series_uuid(value::DeterministicMetadata) = value.time_series_uuid
 """Get [`DeterministicMetadata`](@ref) `horizon`."""
 get_horizon(value::DeterministicMetadata) = value.horizon
+"""Get [`DeterministicMetadata`](@ref) `time_series_type`."""
+get_time_series_type(value::DeterministicMetadata) = value.time_series_type
 """Get [`DeterministicMetadata`](@ref) `scaling_factor_multiplier`."""
 get_scaling_factor_multiplier(value::DeterministicMetadata) = value.scaling_factor_multiplier
 """Get [`DeterministicMetadata`](@ref) `internal`."""
@@ -87,6 +93,8 @@ set_count!(value::DeterministicMetadata, val) = value.count = val
 set_time_series_uuid!(value::DeterministicMetadata, val) = value.time_series_uuid = val
 """Set [`DeterministicMetadata`](@ref) `horizon`."""
 set_horizon!(value::DeterministicMetadata, val) = value.horizon = val
+"""Set [`DeterministicMetadata`](@ref) `time_series_type`."""
+set_time_series_type!(value::DeterministicMetadata, val) = value.time_series_type = val
 """Set [`DeterministicMetadata`](@ref) `scaling_factor_multiplier`."""
 set_scaling_factor_multiplier!(value::DeterministicMetadata, val) = value.scaling_factor_multiplier = val
 """Set [`DeterministicMetadata`](@ref) `internal`."""

--- a/src/generated/includes.jl
+++ b/src/generated/includes.jl
@@ -13,6 +13,7 @@ export get_percentiles
 export get_resolution
 export get_scaling_factor_multiplier
 export get_scenario_count
+export get_time_series_type
 export get_time_series_uuid
 export set_count!
 export set_horizon!
@@ -24,4 +25,5 @@ export set_percentiles!
 export set_resolution!
 export set_scaling_factor_multiplier!
 export set_scenario_count!
+export set_time_series_type!
 export set_time_series_uuid!

--- a/src/serialization.jl
+++ b/src/serialization.jl
@@ -148,6 +148,7 @@ function deserialize_struct(::Type{TimeSeriesKey}, data::Dict)
 end
 
 function deserialize_to_dict(::Type{T}, data::Dict) where {T}
+    # Note: mostly duplicated in src/deterministic_metadata.jl
     vals = Dict{Symbol, Any}()
     for (field_name, field_type) in zip(fieldnames(T), fieldtypes(T))
         val = data[string(field_name)]

--- a/src/time_series_utils.jl
+++ b/src/time_series_utils.jl
@@ -8,9 +8,7 @@ const _TS_DATA_TO_METADATA_MAP = Dict(
 )
 
 const _TS_METADATA_TO_DATA_MAP = Dict(
-    DeterministicMetadata => Deterministic,
-    # DeterministicSingleTimeSeries is not necessary. deserialize_time_series will do the
-    # right thing if that type is stored.
+    # DeterministicMetadata is used for two types, and so this cannot be used for it.
     ProbabilisticMetadata => Probabilistic,
     ScenariosMetadata => Scenarios,
     SingleTimeSeriesMetadata => SingleTimeSeries,
@@ -20,6 +18,10 @@ function time_series_data_to_metadata(::Type{T}) where {T <: TimeSeriesData}
     return _TS_DATA_TO_METADATA_MAP[T]
 end
 
-function time_series_metadata_to_data(::Type{T}) where {T <: TimeSeriesMetadata}
-    return _TS_METADATA_TO_DATA_MAP[T]
+function time_series_metadata_to_data(ts_metadata::TimeSeriesMetadata)
+    return _TS_METADATA_TO_DATA_MAP[typeof(ts_metadata)]
+end
+
+function time_series_metadata_to_data(ts_metadata::DeterministicMetadata)
+    return ts_metadata.time_series_type
 end


### PR DESCRIPTION
This fixes a bug that caused the function to return instances of
Deterministic when the caller asked for DeterministicSingleTimeSeries.
There was ambiguity in the mapping of DeterministicMetadata to the
actual time series type. This change makes the mapping explicit.