### PR TITLE
Change the cp system command used for Windows

### DIFF
--- a/src/utils/utils.jl
+++ b/src/utils/utils.jl
@@ -383,14 +383,10 @@ get_type_from_strings(module_name, type) = getfield(get_module(module_name), Sym
 # This function is used instead of cp given
 # https://github.com/JuliaLang/julia/issues/30723
 function copy_file(src::AbstractString, dst::AbstractString)
-    try
+    if Sys.iswindows()
+        run(`cmd /c copy /Y $(src) $(dst)`)
+    else
         run(`cp -f $(src) $(dst)`)
-    catch e
-        if Sys.iswindows()
-            run(`cmd /c copy /Y $(src) $(dst)`)
-        else
-            rethrow()
-        end
     end
     return
 end


### PR DESCRIPTION
In Julia 1.5.3 the invalid command was causing terminal display issues
in Windows Cmd and PowerShell terminals.


Julia 1.5.3
 ```
julia> run(`cp`)
cp: missing file operand
Try 'cp --help' for more information.
[91m[1mERROR: [22m[39m[91mfailed process: Process(`[4mcp[24m`, ProcessExited(1)) [1][39m
 
Stacktrace:
[1] [1mpipeline_error[22m at [1m.\process.jl:525[22m [inlined]
[2] [1mrun[22m[1m([22m::Cmd; wait::Bool[1m)[22m at [1m.\process.jl:440[22m
[3] [1mrun[22m[1m([22m::Cmd[1m)[22m at [1m.\process.jl:438[22m
[4] top-level scope at [1mREPL[1]:1[22m
```
 
Julia 1.5.0
```
julia> run(`cp`)
cp: missing file operand
Try 'cp --help' for more information.
ERROR: failed process: Process(`cp`, ProcessExited(1)) [1]
 
Stacktrace:
[1] pipeline_error at .\process.jl:525 [inlined]
[2] run(::Cmd; wait::Bool) at .\process.jl:440
[3] run(::Cmd) at .\process.jl:438
[4] top-level scope at REPL[1]:1
```