### PR TITLE
Fix paths for Windows

### DIFF
--- a/src/utils/utils.jl
+++ b/src/utils/utils.jl
@@ -383,10 +383,12 @@ get_type_from_strings(module_name, type) = getfield(get_module(module_name), Sym
 # This function is used instead of cp given
 # https://github.com/JuliaLang/julia/issues/30723
 function copy_file(src::AbstractString, dst::AbstractString)
+    src_path = normpath(src)
+    dst_path = normpath(dst)
     if Sys.iswindows()
-        run(`cmd /c copy /Y $(src) $(dst)`)
+        run(`cmd /c copy /Y $(src_path) $(dst_path)`)
     else
-        run(`cp -f $(src) $(dst)`)
+        run(`cp -f $(src_path) $(dst_path)`)
     end
     return
 end


### PR DESCRIPTION
The copy command was failing if a path contained a forward slash.

This will fix https://github.com/NREL-SIIP/PowerSystems.jl/issues/718