### PR TITLE
Fix printing of TimeSeriesData length in `summary`

### DIFF
--- a/src/utils/print.jl
+++ b/src/utils/print.jl
@@ -59,7 +59,7 @@ function Base.show(io::IO, ::MIME"text/plain", container::TimeSeriesContainer)
 end
 
 function Base.summary(time_series::TimeSeriesData)
-    return "$(typeof(time_series)) time_series ($length(time_series))"
+    return "$(typeof(time_series)) time_series ($(length(time_series)))"
 end
 
 function Base.summary(time_series::TimeSeriesMetadata)

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -46,10 +46,10 @@ end
           "InfrastructureSystems.InfrastructureSystemsComponent[#undef, #undef, #undef]"
 end
 
-struct FakeTimeSeries <: TimeSeriesData end
+struct FakeTimeSeries <: InfrastructureSystems.TimeSeriesData end
 Base.length(::FakeTimeSeries) = 42
 
 @testset "Test TimeSeriesData printing" begin
     @test sprint(show, MIME("text/plain"), FakeTimeSeries()) ==
-        "FakeTimeSeries time_series (42):"
+          "FakeTimeSeries time_series (42):"
 end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -1,4 +1,3 @@
-
 @testset "Test utility functions" begin
     concrete_types = IS.get_all_concrete_subtypes(IS.InfrastructureSystemsComponent)
     @test length([x for x in concrete_types if isconcretetype(x)]) == length(concrete_types)
@@ -45,4 +44,12 @@ end
     v = Vector{IS.InfrastructureSystemsComponent}(undef, 3)
     @test sprint(show, v) ==
           "InfrastructureSystems.InfrastructureSystemsComponent[#undef, #undef, #undef]"
+end
+
+struct FakeTimeSeries <: TimeSeriesData end
+Base.length(::FakeTimeSeries) = 42
+
+@testset "Test TimeSeriesData printing" begin
+    @test sprint(show, MIME("text/plain"), FakeTimeSeries()) ==
+        "FakeTimeSeries time_series (42):"
 end


### PR DESCRIPTION
Setup: 
```julia
julia> using InfrastructureSystems, TimeSeries, Dates

julia> resolution = Dates.Hour(1);

julia> dates = range(DateTime("2020-01-01T00:00:00"), step = resolution, length = 2);

julia> data = TimeArray(dates, ones(2));
```

On `master`:
```julia
julia> InfrastructureSystems.SingleTimeSeries("max_active_power", data)
InfrastructureSystems.SingleTimeSeries time_series (length(time_series)):
   name: max_active_power
   data: 2×1 TimeArray{Float64, 1, DateTime, Vector{Float64}} 2020-01-01T00:00:00 to 2020-01-01T01:00:00
│                     │ A     │
├─────────────────────┼───────┤
│ 2020-01-01T00:00:00 │ 1.0   │
│ 2020-01-01T01:00:00 │ 1.0   │
   scaling_factor_multiplier: nothing
```
(note the `summary` line has `time_series (length(time_series)):`)

This PR:
```julia
julia> time_series = InfrastructureSystems.SingleTimeSeries("max_active_power", data)
InfrastructureSystems.SingleTimeSeries time_series (2):
   name: max_active_power
   data: 2×1 TimeArray{Float64, 1, DateTime, Vector{Float64}} 2020-01-01T00:00:00 to 2020-01-01T01:00:00
│                     │ A     │
├─────────────────────┼───────┤
│ 2020-01-01T00:00:00 │ 1.0   │
│ 2020-01-01T01:00:00 │ 1.0   │
   scaling_factor_multiplier: nothing
```