### PR TITLE
Fix transform_time_series when interval and resolution are equal

### DIFF
--- a/src/component.jl
+++ b/src/component.jl
@@ -52,7 +52,6 @@ function _get_columns(start_time, count, ts_metadata::ForecastMetadata)
     if window_count > 1
         index = Int(offset / interval) + 1
     else
-        @assert_op interval == Dates.Millisecond(0)
         index = 1
     end
     if count === nothing

--- a/src/utils/utils.jl
+++ b/src/utils/utils.jl
@@ -400,11 +400,10 @@ function get_initial_times(
 )
     if count == 0
         return []
-    elseif count == 1
-        @assert_op interval == Dates.Second(0)
-        return range(initial_timestamp; stop = initial_timestamp, step = Dates.Second(1))
+    elseif interval == Dates.Second(0)
+        return [initial_timestamp]
     end
-    @assert interval != Dates.Second(0) "initial_timestamp=$initial_timestamp interval=$interval count=$count"
+
     return range(initial_timestamp; length = count, step = interval)
 end
 

--- a/test/test_time_series.jl
+++ b/test/test_time_series.jl
@@ -539,6 +539,35 @@ end
     @test IS.get_interval(forecast) == Dates.Second(0)
 end
 
+@testset "Test DeterministicSingleTimeSeries with interval = resolution" begin
+    sys = IS.SystemData(time_series_in_memory = true)
+    component = IS.TestComponent("Component1", 5)
+    IS.add_component!(sys, component)
+
+    resolution = Dates.Hour(1)
+    horizon = 24
+    dates = collect(
+        range(Dates.DateTime("2020-01-01T00:00:00"); length = horizon, step = resolution),
+    )
+    data = collect(1:horizon)
+    ta = TimeSeries.TimeArray(dates, data, [IS.get_name(component)])
+    name = "val"
+    ts = IS.SingleTimeSeries(name, ta)
+    IS.add_time_series!(sys, component, ts)
+
+    interval = resolution
+    IS.transform_single_time_series!(
+        sys,
+        IS.DeterministicSingleTimeSeries,
+        horizon,
+        interval,
+    )
+
+    initial_times = IS.get_forecast_initial_times(sys)
+    forecast = IS.get_time_series(IS.DeterministicSingleTimeSeries, component, name)
+    @test IS.get_interval(forecast) == interval
+end
+
 @testset "Test component removal with DeterministicSingleTimeSeries" begin
     sys = IS.SystemData()
     component = IS.TestComponent("Component1", 5)
@@ -1213,7 +1242,7 @@ end
     component = IS.TestComponent(name, 5)
     IS.add_component!(sys, component)
 
-    @test IS.get_forecast_initial_times(sys) == []
+    @test isempty(IS.get_forecast_initial_times(sys))
 
     resolution = Dates.Hour(1)
     initial_time = Dates.DateTime("2020-09-01")

--- a/test/test_time_series.jl
+++ b/test/test_time_series.jl
@@ -535,6 +535,8 @@ end
         interval,
     )
 
+    initial_times = collect(IS.get_forecast_initial_times(sys))
+    @test initial_times == [Dates.DateTime("2020-01-01T00:00:00")]
     forecast = IS.get_time_series(IS.DeterministicSingleTimeSeries, component, name)
     @test IS.get_interval(forecast) == Dates.Second(0)
 end
@@ -563,7 +565,8 @@ end
         interval,
     )
 
-    initial_times = IS.get_forecast_initial_times(sys)
+    initial_times = collect(IS.get_forecast_initial_times(sys))
+    @test initial_times == [Dates.DateTime("2020-01-01T00:00:00")]
     forecast = IS.get_time_series(IS.DeterministicSingleTimeSeries, component, name)
     @test IS.get_interval(forecast) == interval
 end


### PR DESCRIPTION
Fixes #211 

The previous checks for forecast count == 1 and interval == 0 were invalid.