### PR TITLE
changing error to warning for consistency

### DIFF
--- a/src/system_data.jl
+++ b/src/system_data.jl
@@ -435,11 +435,7 @@ function set_component!(metadata::TimeSeriesFileMetadata, data::SystemData, mod:
         metadata.component =
             get_component(category, data.components, metadata.component_name)
         if isnothing(metadata.component)
-            throw(
-                DataFormatError(
-                    "no component category=$category name=$(metadata.component_name)",
-                ),
-            )
+            @warn "no component category=$category name=$(metadata.component_name)"
         end
     else
         # Note: this could dispatch to higher-level modules that reimplement it.


### PR DESCRIPTION
This PR makes the behavior of `set_component!` consistent when it fails to find any component specified with a concrete type or with an abstract type by issuing a warning in both cases. Previously if `set_component!` was given an abstract type and failed to find a match, it would issue a warning, and if it was given a concrete type it would throw an error. Additionally, this makes it easier to have a time series metadata file with entries for components that don't exist in a system.