### PR TITLE
Add support for masked components

### DIFF
--- a/src/components.jl
+++ b/src/components.jl
@@ -35,7 +35,6 @@ function add_component!(
     components::Components,
     component::T;
     skip_validation = false,
-    deserialization_in_progress = false,
     allow_existing_time_series = false,
 ) where {T <: InfrastructureSystemsComponent}
     component_name = get_name(component)
@@ -51,9 +50,7 @@ function add_component!(
 
     !skip_validation && check_component(components, component)
 
-    if !deserialization_in_progress &&
-       !allow_existing_time_series &&
-       has_time_series(component)
+    if !allow_existing_time_series && has_time_series(component)
         throw(ArgumentError("cannot add a component with time_series: $component"))
     end
 

--- a/src/components.jl
+++ b/src/components.jl
@@ -36,6 +36,7 @@ function add_component!(
     component::T;
     skip_validation = false,
     deserialization_in_progress = false,
+    allow_existing_time_series = false,
 ) where {T <: InfrastructureSystemsComponent}
     component_name = get_name(component)
     if !isconcretetype(T)
@@ -50,7 +51,9 @@ function add_component!(
 
     !skip_validation && check_component(components, component)
 
-    if !deserialization_in_progress && has_time_series(component)
+    if !deserialization_in_progress &&
+       !allow_existing_time_series &&
+       has_time_series(component)
         throw(ArgumentError("cannot add a component with time_series: $component"))
     end
 
@@ -113,9 +116,15 @@ Throws ArgumentError if the component is not stored.
 """
 function remove_component!(
     components::Components,
-    component::T,
+    component::T;
+    remove_time_series = true,
 ) where {T <: InfrastructureSystemsComponent}
-    return _remove_component!(T, components, get_name(component))
+    return _remove_component!(
+        T,
+        components,
+        get_name(component),
+        remove_time_series = remove_time_series,
+    )
 end
 
 """
@@ -126,15 +135,17 @@ Throws ArgumentError if the component is not stored.
 function remove_component!(
     ::Type{T},
     components::Components,
-    name::AbstractString,
+    name::AbstractString;
+    remove_time_series = true,
 ) where {T <: InfrastructureSystemsComponent}
-    return _remove_component!(T, components, name)
+    return _remove_component!(T, components, name, remove_time_series = remove_time_series)
 end
 
 function _remove_component!(
     ::Type{T},
     components::Components,
-    name::AbstractString,
+    name::AbstractString;
+    remove_time_series = true,
 ) where {T <: InfrastructureSystemsComponent}
     if !haskey(components.data, T)
         throw(ArgumentError("component $T is not stored"))
@@ -148,7 +159,11 @@ function _remove_component!(
     if isempty(components.data[T])
         pop!(components.data, T)
     end
-    prepare_for_removal!(component)
+
+    if remove_time_series
+        prepare_for_removal!(component)
+    end
+
     @debug "Removed component" T name
     return component
 end
@@ -213,7 +228,7 @@ function get_components_by_name(
     ::Type{T},
     components::Components,
     name::AbstractString,
-)::Vector{T} where {T <: InfrastructureSystemsComponent}
+) where {T <: InfrastructureSystemsComponent}
     if isconcretetype(T)
         throw(ArgumentError("get_components_by_name does not support concrete types: $T"))
     end
@@ -322,4 +337,12 @@ function clear_time_series!(components::Components)
     for component in iterate_components_with_time_series(components)
         clear_time_series!(component)
     end
+end
+
+function is_attached(
+    component::T,
+    components::Components,
+) where {T <: InfrastructureSystemsComponent}
+    !in(T, keys(components.data)) && return false
+    return get_name(component) in keys(components.data[T])
 end

--- a/src/hdf5_time_series_storage.jl
+++ b/src/hdf5_time_series_storage.jl
@@ -619,14 +619,16 @@ function _append_item!(path::HDF5.Group, name::AbstractString, value::AbstractSt
     handle = HDF5.open_object(path, name)
     values = HDF5.read(handle)
     HDF5.close(handle)
-    # PowerSystems.HybridSystem could store the same reference twice for subcomponents.
-    if !in(value, values)
+
+    if in(value, values)
+        # Just in case any component tries to store the same reference twice.
+        return nothing
+    else
         push!(values, value)
     end
 
-    ret = HDF5.delete_object(path, name)
-    @assert_op ret === nothing
-
+    # Delete and re-write.
+    HDF5.delete_object(path, name)
     path[name] = values
     @debug "Appended $value to $name" values
 end


### PR DESCRIPTION
This PR enables full support of HybridSystems in PowerSystems. PowerSystems code will "mask" all subcomponents in a HybridSystem. Those subcomponents will still be managed by the system but will not be exposed in functions like `get_components`.