### PR TITLE
Catch `ResolverError` to reduce possibility misleading failures from integration tests

### DIFF
--- a/.github/workflows/cross-package-test.yml
+++ b/.github/workflows/cross-package-test.yml
@@ -26,9 +26,9 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: NREL-SIIP/${{matrix.package_name}}.jl
-          path: "${{matrix.package_name}}.jl"
+          path: downstream
       - name: Run the tests
-        shell: julia --project="${{matrix.package_name}}.jl" {0}
+        shell: julia --project=downstream {0}
         run: |
           using Pkg
           try

--- a/.github/workflows/cross-package-test.yml
+++ b/.github/workflows/cross-package-test.yml
@@ -28,5 +28,19 @@ jobs:
           repository: NREL-SIIP/${{matrix.package_name}}.jl
           path: "${{matrix.package_name}}.jl"
       - name: Run the tests
-        run: julia --project="${{matrix.package_name}}.jl" -e "using Pkg; Pkg.develop(PackageSpec(path=\"./\")); Pkg.update(); Pkg.test()"
-        shell: bash
+        shell: julia --project="${{matrix.package_name}}.jl" {0}
+        run: |
+          using Pkg
+          try
+            # Force it to use this PR's version of the package
+            Pkg.develop(PackageSpec(path="."))  # resolver may fail with main deps
+            Pkg.update()
+            Pkg.test()  # resolver may fail with test time deps
+          catch err
+            err isa Pkg.Resolve.ResolverError || rethrow()
+            # If we can't resolve that means this is incompatible by SemVer, and this is fine.
+            # It means we marked this as a breaking change, so we don't need to worry about
+            # mistakenly introducing a breaking change as we have intentionally made one.
+            @info "Not compatible with this release. No problem." exception=err
+            exit(0)  # Exit immediately, as a success
+          end


### PR DESCRIPTION
When looking into #222, i noticed this package had integration tests with downstream packages - which is great. And they even caught the breaking change in #220 (which were then fixed in #221)

But i noticed one tiny way that might be improved: the integration tests currently allow false negatives, which slightly reduces the signal-noise ratio. This PR changes it so that a PR doesn't fail the integration test if it introduces a breaking change but also bumps to a breaking version; it changes the the Julia code that runs the test to catch a ResolverError and exit with success in that case.

(This is not related to #220, this is just something i saw in passing when investigating if we could further reduce the risk of accidental breaking changes, which hopefully this does by meaning we have even more reason to trust the integration tests)