### PR TITLE
Optimize storage of time series

### DIFF
--- a/docs/src/dev_guide/auto_generation.md
+++ b/docs/src/dev_guide/auto_generation.md
@@ -56,7 +56,8 @@ generated. This allows you to enter ``val = MyType(nothing)`` in the REPL and
 see the layout of a struct without worrying about valid values.
 - ``valid_range``: Define this as a Dict with ``min`` and ``max`` and
 InfrastructureSystems will validate any value against that range when you add
-the component to the system.
+the component to the system. Use ``null`` if one doesn't apply, such as if there
+is no max limit.
 - ``validation_action``: Define this as ``error`` or ``warn``. If it is
 ``error`` then InfrastructureSystems will raise an exception if the validation
 code detects a problem. Otherwise, it will log a warning.

--- a/docs/src/dev_guide/auto_generation.md
+++ b/docs/src/dev_guide/auto_generation.md
@@ -25,10 +25,45 @@ reasons to consider using this approach:
 InfrastructureSystems.generate_structs("./src/descriptors/power_system_structs.json", "./src/models/generated")
 ```
 
+## Struct Descriptor Rules
+Each struct descriptor must define the following fields:
+
+- ``struct_name``: Name of struct
+- ``docstring``: Struct docstring
+- ``fields``: Array of struct members. See below for requirements.
+- ``supertype``: Declare the struct with this parent type.
+
+Required fields for each struct member:
+
+- ``name``: Name of field
+- ``data_type``: Type of field
+
+Optional fields for each struct member:
+
+- ``accessor_module``: Set this if the the getter/setter function are
+reimplementing a method defined in a different module.
+- ``comment``: Field comment
+- ``default``: The constructors will define this as a default value.
+- ``exclude_setter``: Do not generate a setter function for this field.
+- ``internal_default``: Set to true for non-user-facing fields like
+InfrastructureSystemsInternal that have default values.
+- ``needs_conversion``: Set to true if the getter function needs apply unit
+conversion. The type must implement ``get_value(::InfrastructureSystemsComponent,
+::Type) for this combination of component type and member type.``
+- ``null_value``: Value to indicate the value is null, such as 0.0 for floats.
+If all members in the struct define this field then a "demo" constructor will be
+generated. This allows you to enter ``val = MyType(nothing)`` in the REPL and
+see the layout of a struct without worrying about valid values.
+- ``valid_range``: Define this as a Dict with ``min`` and ``max`` and
+InfrastructureSystems will validate any value against that range when you add
+the component to the system.
+- ``validation_action``: Define this as ``error`` or ``warn``. If it is
+``error`` then InfrastructureSystems will raise an exception if the validation
+code detects a problem. Otherwise, it will log a warning.
+
+
 *Notes*:
 
-- The code generation template provides several options which are not yet
-  formally documented. Browse the PowerSystems example or the generation script.
 - You will need to decide how to manage the generated files. The SIIP packages keep the
   generated code in the git repository. This is not required.
   You could choose to generate them at startup.

--- a/docs/src/dev_guide/time_series.md
+++ b/docs/src/dev_guide/time_series.md
@@ -38,3 +38,63 @@ deserialize the system.
 1. Add an instance of `InfrastructureSystems.TimeSeriesContainer` to the component struct.
 2. Implement the method `InfrastructureSystems.get_time_series_container` for the
    component. It must return the TimeSeriesContainer object.
+
+
+## Data Format
+Time series arrays are stored in an HDF5 file accoring the format described here.
+
+The root path ``/time_series`` defines these HDF5 attributes to control deserialization:
+
+- ``data_format_version``: Designates the InfrastructureSystems format for the file.
+- ``compression_enabled``: Specifies whether compression is enabled and will be used for new time series.
+- ``compression_type``: Specifies the type of compression being used.
+- ``compression_level``: Specifies the level of compression being used.
+- ``compression_shuffle``: Specifies whether the shuffle filter is being used.
+
+Each time series array is stored in an HDF5 group named with the array's UUID.
+Each group contains a dataset called ``data`` which contains the actual data.
+Each group also contains a group called ``component_references`` which contains
+an HDF5 attribute for each component reference. The component reference uses the
+format ``<component_uuid>__<time_series_name>``.
+
+Each time series group defines attributes that control how the data will be deserialized into a ``TimeSeriesData`` instance.
+
+- ``initial_timestamp``: Defines the first timestamp of the array. (All times are not stored.)
+- ``resolution``: Resolution of the time series in milliseconds.
+- ``type``: Type of the time series. Subtype of ``TimeSeriesData``.
+- ``module``: Module that defines the type of the time series.
+- ``data_type``: Describes the type of the array stored.
+
+Example:
+
+```
+/time_series
+    data_format_version = "1.0.1"
+    compression_enabled = 1
+    /9f02f706-3394-4af3-8084-8903d302cbba
+        /component_references
+            0b6ecb61-8e8d-4563-b795-f001246c3ea5__max_active_power
+            613ddbc2-b666-4c9d-adb5-fa69e7f40a95__max_active_power
+        /data
+```
+
+## Debugging
+The HDF Group provides tools to inspect and manipulate files. Refer to their
+[website](https://support.hdfgroup.org/products/hdf5_tools/).
+
+``HDFView`` is especially useful for viewing data. Note that using ``h5ls`` and
+``h5dump`` in a terminal combined with UNIX tools like ``grep`` can sometimes be
+faster.
+
+
+## Maintenance
+
+If you delete time series arrays in your system you may notice that the actual
+size of the HDF5 does not decrease. The only way to recover this space is to
+build a new file with only the active objects. The HDF5 tools package provides
+the tool ``h5repack`` for this purpose.
+
+```bash
+$ h5repack time_series.h5 new.h5
+$ mv new.h5 time_series.h5
+```

--- a/docs/src/dev_guide/time_series.md
+++ b/docs/src/dev_guide/time_series.md
@@ -41,7 +41,9 @@ deserialize the system.
 
 
 ## Data Format
-Time series arrays are stored in an HDF5 file accoring the format described here.
+Time series arrays are stored in an
+[HDF5](https://support.hdfgroup.org/HDF5/whatishdf5.html) file according the
+format described here.
 
 The root path ``/time_series`` defines these HDF5 attributes to control deserialization:
 
@@ -57,7 +59,8 @@ Each group also contains a group called ``component_references`` which contains
 an HDF5 attribute for each component reference. The component reference uses the
 format ``<component_uuid>__<time_series_name>``.
 
-Each time series group defines attributes that control how the data will be deserialized into a ``TimeSeriesData`` instance.
+Each time series group defines attributes that control how the data will be
+deserialized into a ``TimeSeriesData`` instance.
 
 - ``initial_timestamp``: Defines the first timestamp of the array. (All times are not stored.)
 - ``resolution``: Resolution of the time series in milliseconds.

--- a/src/hdf5_time_series_storage.jl
+++ b/src/hdf5_time_series_storage.jl
@@ -99,6 +99,8 @@ function from_file(
     return storage
 end
 
+get_compression_settings(storage::Hdf5TimeSeriesStorage) = storage.compression
+
 get_file_path(storage::Hdf5TimeSeriesStorage) = storage.file_path
 
 function read_data_format_version(storage::Hdf5TimeSeriesStorage)

--- a/src/hdf5_time_series_storage.jl
+++ b/src/hdf5_time_series_storage.jl
@@ -2,6 +2,9 @@
 import HDF5
 
 const HDF5_TS_ROOT_PATH = "time_series"
+const TIME_SERIES_DATA_FORMAT_VERSION = "1.0.1"
+const TIME_SERIES_VERSION_KEY = "data_format_version"
+const COMPONENT_REFERENCES_KEY = "component_references"
 
 """
 Stores all time series data in an HDF5 file.
@@ -12,6 +15,7 @@ no more references to the storage object.
 mutable struct Hdf5TimeSeriesStorage <: TimeSeriesStorage
     file_path::String
     read_only::Bool
+    compression::CompressionSettings
 end
 
 """
@@ -38,6 +42,7 @@ function Hdf5TimeSeriesStorage(
     filename = nothing,
     directory = nothing,
     read_only = false,
+    compression = CompressionSettings(),
 )
     if create_file
         if isnothing(filename)
@@ -48,13 +53,13 @@ function Hdf5TimeSeriesStorage(
             close(io)
         end
 
-        storage = Hdf5TimeSeriesStorage(filename, read_only)
+        storage = Hdf5TimeSeriesStorage(filename, read_only, compression)
         _make_file(storage)
     else
-        storage = Hdf5TimeSeriesStorage(filename, read_only)
+        storage = Hdf5TimeSeriesStorage(filename, read_only, compression)
     end
 
-    @debug "Constructed new Hdf5TimeSeriesStorage" storage.file_path read_only
+    @debug "Constructed new Hdf5TimeSeriesStorage" storage.file_path read_only compression
 
     return storage
 end
@@ -80,12 +85,31 @@ function from_file(
         close(io)
         copy_file(filename, file_path)
     end
+
     storage = Hdf5TimeSeriesStorage(false; filename = file_path, read_only = read_only)
-    @info "Loaded time series from storage file existing=$filename new=$(storage.file_path)"
+    if !read_only
+        version = read_data_format_version(storage)
+        if version == "1.0.0"
+            _convert_from_1_0_0!(storage)
+        end
+        _deserialize_compression_settings!(storage)
+    end
+
+    @info "Loaded time series from storage file existing=$filename new=$(storage.file_path) compression=$(storage.compression)"
     return storage
 end
 
 get_file_path(storage::Hdf5TimeSeriesStorage) = storage.file_path
+
+function read_data_format_version(storage::Hdf5TimeSeriesStorage)
+    HDF5.h5open(storage.file_path, "r") do file
+        root = _get_root(storage, file)
+        if !haskey(HDF5.attributes(root), TIME_SERIES_VERSION_KEY)
+            return "1.0.0"
+        end
+        return HDF5.read(HDF5.attributes(root)[TIME_SERIES_VERSION_KEY])
+    end
+end
 
 function serialize_time_series!(
     storage::Hdf5TimeSeriesStorage,
@@ -102,16 +126,34 @@ function serialize_time_series!(
         if !haskey(root, uuid)
             HDF5.create_group(root, uuid)
             path = root[uuid]
+            # Create a group to store component references as attributes.
+            # Use this instead of this time series' group or the dataset so that
+            # the only attributes are component references.
+            component_refs = HDF5.create_group(path, COMPONENT_REFERENCES_KEY)
             data = get_array_for_hdf(ts)
-            path["data"] = data
+            settings = storage.compression
+            if settings.enabled
+                if settings.type == CompressionTypes.BLOSC
+                    path["data", blosc = settings.level] = data
+                elseif settings.type == CompressionTypes.DEFLATE
+                    if settings.shuffle
+                        path["data", shuffle = (), deflate = settings.level] = data
+                    else
+                        path["data", deflate = settings.level] = data
+                    end
+                else
+                    error("not implemented for type=$(settings.type)")
+                end
+            else
+                path["data"] = data
+            end
             _write_time_series_attributes!(storage, ts, path)
-            path["components"] = [component_name]
             @debug "Create new time series entry." uuid component_uuid name
         else
-            path = root[uuid]
+            component_refs = root[uuid][COMPONENT_REFERENCES_KEY]
             @debug "Add reference to existing time series entry." uuid component_uuid name
-            _append_item!(path, "components", component_name)
         end
+        HDF5.attributes(component_refs)[component_name] = true
     end
 
     return
@@ -220,14 +262,14 @@ function add_time_series_reference!(
     component_name = make_component_name(component_uuid, name)
     HDF5.h5open(storage.file_path, "r+") do file
         root = _get_root(storage, file)
-        path = root[uuid]
-        _append_item!(path, "components", component_name)
+        path = root[uuid][COMPONENT_REFERENCES_KEY]
+        HDF5.attributes(path)[component_name] = true
         @debug "Add reference to existing time series entry." uuid component_uuid name
     end
 end
 
 # TODO: This needs to change if we want to directly convert Hdf5TimeSeriesStorage to
-# InMemoryTimeSeriesStorage, which is currently not supported System deserialization.
+# InMemoryTimeSeriesStorage, which is currently not supported at System deserialization.
 function iterate_time_series(storage::Hdf5TimeSeriesStorage)
     Channel() do channel
         HDF5.h5open(storage.file_path, "r") do file
@@ -242,8 +284,9 @@ function iterate_time_series(storage::Hdf5TimeSeriesStorage)
                 for name in keys(HDF5.attributes(uuid_group))
                     attributes[name] = HDF5.read(HDF5.attributes(uuid_group)[name])
                 end
-                for item in HDF5.read(uuid_group["components"])
-                    component, name = deserialize_component_name(item)
+                refs = uuid_group[COMPONENT_REFERENCES_KEY]
+                for ref in keys(HDF5.attributes(refs))
+                    component, name = deserialize_component_name(ref)
                     put!(channel, (component, name, data, attributes))
                 end
             end
@@ -276,7 +319,9 @@ function remove_time_series!(
     HDF5.h5open(storage.file_path, "r+") do file
         root = _get_root(storage, file)
         path = _get_time_series_path(root, uuid)
-        if _remove_item!(path, "components", make_component_name(component_uuid, name))
+        components = path[COMPONENT_REFERENCES_KEY]
+        HDF5.delete_attribute(components, make_component_name(component_uuid, name))
+        if isempty(keys(HDF5.attributes(components)))
             @debug "$path has no more references; delete it."
             HDF5.delete_object(path)
         end
@@ -600,8 +645,30 @@ end
 
 function _make_file(storage::Hdf5TimeSeriesStorage)
     HDF5.h5open(storage.file_path, "w") do file
-        HDF5.create_group(file, HDF5_TS_ROOT_PATH)
+        root = HDF5.create_group(file, HDF5_TS_ROOT_PATH)
+        HDF5.attributes(root)[TIME_SERIES_VERSION_KEY] = TIME_SERIES_DATA_FORMAT_VERSION
+        _serialize_compression_settings(storage, root)
     end
+end
+
+function _serialize_compression_settings(storage::Hdf5TimeSeriesStorage, root)
+    HDF5.attributes(root)["compression_enabled"] = storage.compression.enabled
+    HDF5.attributes(root)["compression_type"] = string(storage.compression.type)
+    HDF5.attributes(root)["compression_level"] = storage.compression.level
+    HDF5.attributes(root)["compression_shuffle"] = storage.compression.shuffle
+end
+
+function _deserialize_compression_settings!(storage::Hdf5TimeSeriesStorage)
+    HDF5.h5open(storage.file_path, "r+") do file
+        root = _get_root(storage, file)
+        storage.compression = CompressionSettings(
+            enabled = HDF5.read(HDF5.attributes(root)["compression_enabled"]),
+            type = CompressionTypes(HDF5.read(HDF5.attributes(root)["compression_type"])),
+            level = HDF5.read(HDF5.attributes(root)["compression_level"]),
+            shuffle = HDF5.read(HDF5.attributes(root)["compression_shuffle"]),
+        )
+    end
+    return
 end
 
 _get_root(storage::Hdf5TimeSeriesStorage, file) = file[HDF5_TS_ROOT_PATH]
@@ -613,55 +680,6 @@ function _get_time_series_path(root::HDF5.Group, uuid::UUIDs.UUID)
     end
 
     return root[uuid_str]
-end
-
-function _append_item!(path::HDF5.Group, name::AbstractString, value::AbstractString)
-    handle = HDF5.open_object(path, name)
-    values = HDF5.read(handle)
-    HDF5.close(handle)
-
-    if in(value, values)
-        # Just in case any component tries to store the same reference twice.
-        return nothing
-    else
-        push!(values, value)
-    end
-
-    # Delete and re-write.
-    HDF5.delete_object(path, name)
-    path[name] = values
-    @debug "Appended $value to $name" values
-end
-
-"""
-Removes value from the dataset called name.
-Returns true if the array is empty afterwards.
-"""
-function _remove_item!(path::HDF5.Group, name::AbstractString, value::AbstractString)
-    handle = HDF5.open_object(path, name)
-    vals = HDF5.read(handle)
-    HDF5.close(handle)
-
-    orig_len = length(vals)
-    filter!(x -> x != value, vals)
-    exp_len = orig_len - 1
-    if length(vals) != exp_len
-        throw(
-            ArgumentError(
-                "$value wasn't stored in $name or was stored more than once. " *
-                "exp_len = $exp_len actual = $(length(vals))",
-            ),
-        )
-    end
-
-    # Delete and rewrite.
-    # This is not efficient, but this is expected to be uncommon and not to have
-    # large counts.
-    HDF5.delete_object(path, name)
-    path[name] = vals
-
-    @debug "Removed $value from $name" vals
-    return isempty(vals)
 end
 
 function check_read_only(storage::Hdf5TimeSeriesStorage)
@@ -703,4 +721,27 @@ function compare_values(x::Hdf5TimeSeriesStorage, y::Hdf5TimeSeriesStorage)::Boo
     end
 
     return true
+end
+
+function _convert_from_1_0_0!(storage::Hdf5TimeSeriesStorage)
+    # 1.0.0 version did not support compression.
+    # 1.0.0 stored component name/UUID pairs in a dataset.
+    # That wasn't efficient if a user added many shared references.
+    HDF5.h5open(storage.file_path, "r+") do file
+        root = _get_root(storage, file)
+        for uuid_group in root
+            components = HDF5.create_group(uuid_group, COMPONENT_REFERENCES_KEY)
+            component_names = uuid_group["components"][:]
+            for name in component_names
+                HDF5.attributes(components)[name] = true
+            end
+            HDF5.delete_object(uuid_group["components"])
+        end
+
+        HDF5.attributes(root)[TIME_SERIES_VERSION_KEY] = TIME_SERIES_DATA_FORMAT_VERSION
+        compression = CompressionSettings()
+        _serialize_compression_settings(storage, root)
+    end
+
+    @debug "Converted file from 1.0.0 format"
 end

--- a/src/in_memory_time_series_storage.jl
+++ b/src/in_memory_time_series_storage.jl
@@ -39,6 +39,9 @@ end
 
 check_read_only(storage::InMemoryTimeSeriesStorage) = nothing
 
+get_compression_settings(storage::InMemoryTimeSeriesStorage) =
+    CompressionSettings(enabled = false)
+
 is_read_only(storage::InMemoryTimeSeriesStorage) = false
 
 function serialize_time_series!(

--- a/src/system_data.jl
+++ b/src/system_data.jl
@@ -681,3 +681,6 @@ clear_components!(data::SystemData) = clear_components!(data.components)
 
 check_components(data::SystemData) = check_components(data.components)
 check_component(data::SystemData, component) = check_component(data.components, component)
+
+get_compression_settings(data::SystemData) =
+    get_compression_settings(data.time_series_storage)

--- a/src/system_data.jl
+++ b/src/system_data.jl
@@ -35,13 +35,15 @@ Construct SystemData to store components and time series data.
   descriptors.
 - `time_series_in_memory = false`: Controls whether time series data is stored in memory or
   in a file.
-- time_series_directory = nothing`: Controls what directory time series data is stored in.
+- `time_series_directory = nothing`: Controls what directory time series data is stored in.
   Default is tempdir().
+- `compression = CompressionSettings()`: Controls compression of time series data.
 """
 function SystemData(;
     validation_descriptor_file = nothing,
     time_series_in_memory = false,
     time_series_directory = nothing,
+    compression = CompressionSettings(),
 )
     if isnothing(validation_descriptor_file)
         validation_descriptors = Vector()
@@ -52,6 +54,7 @@ function SystemData(;
     ts_storage = make_time_series_storage(;
         in_memory = time_series_in_memory,
         directory = time_series_directory,
+        compression = compression,
     )
     components = Components(ts_storage, validation_descriptors)
     masked_components = Components(ts_storage, validation_descriptors)

--- a/src/time_series_storage.jl
+++ b/src/time_series_storage.jl
@@ -14,17 +14,47 @@ All subtypes must implement:
 """
 abstract type TimeSeriesStorage end
 
+const DEFAULT_COMPRESSION = false
+
+@scoped_enum(CompressionTypes, BLOSC = 0, DEFLATE = 1,)
+
+"""
+Provides customization of HDF5 compression settings.
+Refer to the HDF5.jl and HDF5 documention for more information.
+"""
+struct CompressionSettings
+    "Controls whether compression is enabled."
+    enabled::Bool
+    "Specifies the type of compression to use."
+    type::CompressionTypes
+    "Supported values are 0-9. Higher values deliver better compression ratios but take longer."
+    level::Int
+    "Controls whether to enable the shuffle filter. Used with DEFLATE."
+    shuffle::Bool
+end
+
+function CompressionSettings(;
+    enabled = DEFAULT_COMPRESSION,
+    type = CompressionTypes.DEFLATE,
+    level = 3,
+    shuffle = true,
+)
+    return CompressionSettings(enabled, type, level, shuffle)
+end
+
 function make_time_series_storage(;
     in_memory = false,
     filename = nothing,
     directory = nothing,
+    compression = CompressionSettings(),
 )
     if in_memory
         storage = InMemoryTimeSeriesStorage()
     elseif !isnothing(filename)
-        storage = Hdf5TimeSeriesStorage(; filename = filename)
+        storage = Hdf5TimeSeriesStorage(; filename = filename, compression = compression)
     else
-        storage = Hdf5TimeSeriesStorage(true; directory = directory)
+        storage =
+            Hdf5TimeSeriesStorage(true; directory = directory, compression = compression)
     end
 
     return storage

--- a/src/time_series_storage.jl
+++ b/src/time_series_storage.jl
@@ -3,14 +3,15 @@
 Abstract type for time series storage implementations.
 
 All subtypes must implement:
-- serialize_time_series!
 - add_time_series_reference!
-- remove_time_series!
-- deserialize_time_series
-- clear_time_series!
-- get_num_time_series
 - check_read_only
+- clear_time_series!
+- deserialize_time_series
+- get_compression_settings
+- get_num_time_series
 - is_read_only
+- remove_time_series!
+- serialize_time_series!
 """
 abstract type TimeSeriesStorage end
 

--- a/test/test_system_data.jl
+++ b/test/test_system_data.jl
@@ -73,3 +73,11 @@ end
     @test length(collect(IS.get_time_series_multiple(data, type = IS.SingleTimeSeries))) ==
           3
 end
+
+@testset "Test compression settings" begin
+    none = IS.CompressionSettings(enabled = false)
+    @test IS.get_compression_settings(IS.SystemData()) == none
+    @test IS.get_compression_settings(IS.SystemData(time_series_in_memory = true)) == none
+    settings = IS.CompressionSettings(enabled = true, type = IS.CompressionTypes.DEFLATE)
+    @test IS.get_compression_settings(IS.SystemData(compression = settings)) == settings
+end

--- a/test/test_time_series_storage.jl
+++ b/test/test_time_series_storage.jl
@@ -152,3 +152,46 @@ end
         test_clear(IS.make_time_series_storage(; in_memory = in_memory))
     end
 end
+
+@testset "Test data format version" begin
+    storage = IS.make_time_series_storage(in_memory = false)
+    @test IS.read_data_format_version(storage) == IS.TIME_SERIES_DATA_FORMAT_VERSION
+end
+
+@testset "Test compression" begin
+    in_memory = false
+    for type in (IS.CompressionTypes.BLOSC, IS.CompressionTypes.DEFLATE)
+        for shuffle in (true, false)
+            compression = IS.CompressionSettings(
+                enabled = true,
+                type = type,
+                level = 5,
+                shuffle = shuffle,
+            )
+            test_add_remove(
+                IS.make_time_series_storage(;
+                    in_memory = in_memory,
+                    compression = compression,
+                ),
+            )
+            test_add_references(
+                IS.make_time_series_storage(;
+                    in_memory = in_memory,
+                    compression = compression,
+                ),
+            )
+            test_get_subset(
+                IS.make_time_series_storage(;
+                    in_memory = in_memory,
+                    compression = compression,
+                ),
+            )
+            test_clear(
+                IS.make_time_series_storage(;
+                    in_memory = in_memory,
+                    compression = compression,
+                ),
+            )
+        end
+    end
+end


### PR DESCRIPTION
This makes two changes:
1. Add option to compress time series data.
2. Change how shared time series references are stored. The earlier
   method caused stranded space.

These changes required the addition of a format version so that we can
maintain backwards compatibility with existing datasets.

I also added some documentation. I added a description of the time series HDF5 format. I also added descriptor rules for our auto-generation code since more people are using that feature.

Regarding compression, I'm thinking that we can expose this with kwargs to the System constructor. We could provide a simple `enable_compression` as well as `compression` that take the `CompressionSettings` struct defined here.