### PR TITLE
Add filtering of log messages by group - part 2

### DIFF
--- a/docs/src/dev_guide/logging.md
+++ b/docs/src/dev_guide/logging.md
@@ -48,6 +48,28 @@ logger = configure_logging("logging_config.toml")
 
 ### Enable debug logging for code you are debugging but not for noisy areas you don't care about.
 
+InfrastructureSystems uses the `_group` field of a log event to perform
+additional filtering. All debug log messages that run frequently should have
+this field defined.
+
+Note that the default value of `_group` for a log event is its filename. Refer
+to the [Julia
+docs](https://docs.julialang.org/en/v1/stdlib/Logging/#Log-event-structure) for
+more information.
+
+Run this in the REPL to see commonly-used groups in InfrastructureSystems:
+
+```julia
+@show InfrastructureSystems.LOG_GROUPS
+```
+
+You can tell InfrastructureSystems to filter out messages from a particular
+group in two ways:
+
+1. Specify the group level in the `logging_config.toml` file mentioned above
+   and configure logging with it.
+2. Change the logger dynamically from with Julia. Here is an example:
+
 ```julia
 logger = configure_logging(console_level = Logging.Debug)
 InfrastructureSystems.set_group_level!(logger, InfrastructureSystems.LOG_GROUP_TIME_SERIES)

--- a/docs/src/dev_guide/tests.md
+++ b/docs/src/dev_guide/tests.md
@@ -25,6 +25,8 @@ julia> ENV["SIIP_LOGGING_CONFIG"] = "logging_config.toml"
 julia> include("test/runtests.jl")
 ```
 
+**Note** that you can filter out noisy log groups in this file.
+
 The unit test module appends a summary of all log message counts to the log
 file.  If a message is logged too frequently then consider tagging that message
 with maxlog=X to suppress it.

--- a/src/deterministic_metadata.jl
+++ b/src/deterministic_metadata.jl
@@ -15,7 +15,7 @@ end
 function serialize(::Type{<:T}) where {T <: AbstractDeterministic}
     # This currently cannot be done for all InfrastructureSystemsTypes.
     # Some are encoded directly as strings.
-    @debug "serialize" T
+    @debug "serialize" _group = LOG_GROUP_SERIALIZATION T
     data = Dict{String, Any}()
     add_serialization_metadata!(data, T)
     return data

--- a/src/single_time_series.jl
+++ b/src/single_time_series.jl
@@ -137,7 +137,7 @@ function SingleTimeSeries(time_series::Vector{SingleTimeSeries})
         data = ta,
         scaling_factor_multiplier = time_series[1].scaling_factor_multiplier,
     )
-    @debug "concatenated time_series" time_series
+    @debug "concatenated time_series" LOG_GROUP_TIME_SERIES time_series
     return time_series
 end
 

--- a/src/utils/logging.jl
+++ b/src/utils/logging.jl
@@ -6,6 +6,7 @@ const LOG_GROUP_PARSING = :Parsing
 const LOG_GROUP_RECORDER = :Recorder
 const LOG_GROUP_SERIALIZATION = :Serialization
 const LOG_GROUP_SYSTEM = :System
+const LOG_GROUP_SYSTEM_CHECKS = :SystemChecks
 const LOG_GROUP_TIME_SERIES = :TimeSeries
 
 # Try to keep this updated so that users can check the known groups in the REPL.

--- a/src/utils/logging_config.toml
+++ b/src/utils/logging_config.toml
@@ -8,10 +8,10 @@ file_mode = "w+"
 set_global = true
 
 ["group_levels"]
-# Set these to Info to suppress the group when debug logging is enabled.
+# Uncomment these to suppress the group when debug logging is enabled.
 # You can also add the base name of any file (without '.jl') to suppress its debug logging.
-Parsing = "Debug"
-Recorder = "Debug"
-System = "Debug"
-Serialization = "Debug"
-TimeSeries = "Debug"
+#Parsing = "Info"
+#Recorder = "Info"
+#System = "Info"
+#Serialization = "Info"
+#TimeSeries = "Info"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -74,12 +74,6 @@ function get_logging_level_from_env(env_name::String, default)
     return IS.get_logging_level(level)
 end
 
-function get_exclude_from_debug_logging()
-    group_levels = Dict{Symbol, Base.LogLevel}()
-    groups = get(ENV, "SIIP_EXCLUDE_FROM_DEBUG_LOG", "")
-    return Dict(Symbol(x) => Logging.Error for x in split(groups, ",") if x != "")
-end
-
 function run_tests()
     logging_config_filename = get(ENV, "SIIP_LOGGING_CONFIG", nothing)
     if logging_config_filename !== nothing


### PR DESCRIPTION
I found a few missing items when implementing log filtering support in PSY.