### PR TITLE
Optimize deepcopy of system

### DIFF
--- a/src/hdf5_time_series_storage.jl
+++ b/src/hdf5_time_series_storage.jl
@@ -99,6 +99,27 @@ function from_file(
     return storage
 end
 
+"""
+Copy the time series data to a new file. This should get called when the system is
+undergoing a deepcopy.
+
+# Arguments
+- `storage::Hdf5TimeSeriesStorage`: storage instance
+- `directory::String`: If nothing, use tempdir
+"""
+function copy_to_new_file!(storage::Hdf5TimeSeriesStorage, directory = nothing)
+    if directory === nothing
+        directory = tempdir()
+    end
+
+    # If we ever choose to keep the HDF5 file open then this will break.
+    # Any open buffers will need to be flushed.
+    filename, io = mktemp(directory)
+    close(io)
+    copy_file(get_file_path(storage), filename)
+    storage.file_path = filename
+end
+
 get_compression_settings(storage::Hdf5TimeSeriesStorage) = storage.compression
 
 get_file_path(storage::Hdf5TimeSeriesStorage) = storage.file_path

--- a/src/in_memory_time_series_storage.jl
+++ b/src/in_memory_time_series_storage.jl
@@ -211,11 +211,11 @@ function compare_values(x::InMemoryTimeSeriesStorage, y::InMemoryTimeSeriesStora
             @error "component_names don't match" record_x.component_names record_y.component_names
             return false
         end
-        if TimeSeries.timestamp(record_x.ta.data) != TimeSeries.timestamp(record_y.ta.data)
+        if TimeSeries.timestamp(record_x.ts.data) != TimeSeries.timestamp(record_y.ts.data)
             @error "timestamps don't match" record_x record_y
             return false
         end
-        if TimeSeries.values(record_x.ta.data) != TimeSeries.values(record_y.ta.data)
+        if TimeSeries.values(record_x.ts.data) != TimeSeries.values(record_y.ts.data)
             @error "values don't match" record_x record_y
             return false
         end


### PR DESCRIPTION
This PR does two things related to https://github.com/NREL-SIIP/PowerSystems.jl/issues/762:
- Adds infrastructure to allow PowerSystems to perform a more efficient deepcopy. Instead of serializing and deserializing a system it can call this new function to make a copy of the HDF5 file.
- Fixes a bug that prevented verification of in-memory time series data.