### PR TITLE
Don't serialize an empty time series file

### DIFF
--- a/src/hdf5_time_series_storage.jl
+++ b/src/hdf5_time_series_storage.jl
@@ -99,6 +99,13 @@ function from_file(
     return storage
 end
 
+function Base.isempty(storage::Hdf5TimeSeriesStorage)
+    return HDF5.h5open(storage.file_path, "r+") do file
+        root = _get_root(storage, file)
+        return isempty(keys(root))
+    end
+end
+
 """
 Copy the time series data to a new file. This should get called when the system is
 undergoing a deepcopy.

--- a/src/in_memory_time_series_storage.jl
+++ b/src/in_memory_time_series_storage.jl
@@ -37,6 +37,8 @@ function InMemoryTimeSeriesStorage(hdf5_storage::Hdf5TimeSeriesStorage)
     return storage
 end
 
+Base.isempty(storage::InMemoryTimeSeriesStorage) = isempty(storage.data)
+
 check_read_only(storage::InMemoryTimeSeriesStorage) = nothing
 
 get_compression_settings(storage::InMemoryTimeSeriesStorage) =

--- a/src/time_series_storage.jl
+++ b/src/time_series_storage.jl
@@ -12,6 +12,7 @@ All subtypes must implement:
 - is_read_only
 - remove_time_series!
 - serialize_time_series!
+- Base.isempty
 """
 abstract type TimeSeriesStorage end
 

--- a/test/test_serialization.jl
+++ b/test/test_serialization.jl
@@ -23,8 +23,13 @@ function validate_serialization(sys::IS.SystemData; time_series_read_only = fals
     test_dir = mktempdir()
     path = mv(filename, joinpath(test_dir, filename))
 
+    @test haskey(data, "time_series_storage_file") == !isempty(sys.time_series_storage)
     t_file = splitext(basename(path))[1] * "_" * IS.TIME_SERIES_STORAGE_FILE
-    mv(t_file, joinpath(test_dir, t_file))
+    if haskey(data, "time_series_storage_file")
+        mv(t_file, joinpath(test_dir, t_file))
+    else
+        @test !isfile(t_file)
+    end
     v_file = splitext(basename(path))[1] * "_" * IS.VALIDATION_DESCRIPTOR_FILE
     mv(v_file, joinpath(test_dir, v_file))
 
@@ -77,6 +82,12 @@ end
 @testset "Test JSON serialization of with mutable time series" begin
     sys = create_system_data_shared_time_series(; time_series_in_memory = false)
     sys2, result = validate_serialization(sys; time_series_read_only = false)
+    @test result
+end
+
+@testset "Test JSON serialization with no time series" begin
+    sys = create_system_data(with_time_series = false)
+    sys2, result = validate_serialization(sys)
     @test result
 end
 

--- a/test/test_time_series_storage.jl
+++ b/test/test_time_series_storage.jl
@@ -203,3 +203,16 @@ end
         end
     end
 end
+
+@testset "Test isempty" begin
+    for in_memory in (true, false)
+        storage = IS.make_time_series_storage(in_memory = in_memory)
+        @test isempty(storage)
+        name = "component1"
+        name = "val"
+        component = IS.TestComponent(name, 5)
+        ts = IS.SingleTimeSeries(data = create_time_array(), name = "test")
+        IS.serialize_time_series!(storage, IS.get_uuid(component), name, ts)
+        @test !isempty(storage)
+    end
+end


### PR DESCRIPTION
Fixes https://github.com/NREL-SIIP/PowerSystems.jl/issues/791

This does not require any changes from PowerSystems. However, if user1 serializes a system with no time series with this version of InfrastructureSystems and then shares that system with user2 who has not upgraded, deserialization will fail.