### PR TITLE
Fix bug when adding StaticTimeSeries after Forecast

### DIFF
--- a/src/time_series_parameters.jl
+++ b/src/time_series_parameters.jl
@@ -150,7 +150,7 @@ function _is_uninitialized(params::TimeSeriesParameters)
 end
 
 """
-Return true if `params` match `other` or if `params` is uninitialized.
+Return true if `params` match `other` or if one of them is uninitialized.
 """
 function check_params_compatibility(
     params::TimeSeriesParameters,
@@ -167,7 +167,10 @@ function check_params_compatibility(
         )
     end
 
-    check_params_compatibility(params.forecast_params, other.forecast_params)
+    # `other` might be for a static time series and not have forecast params
+    if !_is_uninitialized(other.forecast_params)
+        check_params_compatibility(params.forecast_params, other.forecast_params)
+    end
 end
 
 function check_add_time_series(params::TimeSeriesParameters, ts::TimeSeriesData)

--- a/test/test_time_series.jl
+++ b/test/test_time_series.jl
@@ -268,7 +268,6 @@ end
 
     initial_time = Dates.DateTime("2020-09-01")
     resolution = Dates.Hour(1)
-    other_time = initial_time + resolution
 
     data = TimeSeries.TimeArray(
         range(initial_time; length = 365, step = resolution),
@@ -1319,12 +1318,19 @@ end
     resolution = Dates.Hour(1)
     initial_time = Dates.DateTime("2020-09-01")
     second_time = initial_time + resolution
-    name = "test"
+    name = "test_forecast"
     horizon = 24
     data = SortedDict(initial_time => ones(horizon), second_time => ones(horizon))
 
     forecast = IS.Deterministic(data = data, name = name, resolution = resolution)
     IS.add_time_series!(sys, component, forecast)
+
+    sts_data = TimeSeries.TimeArray(
+        range(initial_time; length = 365, step = resolution),
+        ones(365),
+    )
+    sts = IS.SingleTimeSeries(data = sts_data, name = "test_sts")
+    IS.add_time_series!(sys, component, sts)
 
     @test IS.get_time_series_resolution(sys) == resolution
     @test IS.get_forecast_window_count(sys) == 2


### PR DESCRIPTION
There was a bug in the consistency checks that caused an exception to be
thrown if a StaticTimeSeries was added after a Forecast.