### PR TITLE
Enhance printing of system and components

### DIFF
--- a/src/component.jl
+++ b/src/component.jl
@@ -380,6 +380,31 @@ function has_time_series(component::InfrastructureSystemsComponent)
     return !isnothing(container) && !isempty(container)
 end
 
+"""
+Return true if the component has time series data of type T.
+"""
+function has_time_series(
+    component::InfrastructureSystemsComponent,
+    ::Type{T},
+) where {T <: TimeSeriesData}
+    container = get_time_series_container(component)
+    if container === nothing
+        return false
+    end
+
+    for key in keys(container.data)
+        if isabstracttype(T)
+            if is_time_series_sub_type(key.time_series_type, T)
+                return true
+            end
+        elseif time_series_data_to_metadata(T) <: key.time_series_type
+            return true
+        end
+    end
+
+    return false
+end
+
 function has_time_series(
     component::InfrastructureSystemsComponent,
     type::Type{<:TimeSeriesMetadata},

--- a/src/time_series_utils.jl
+++ b/src/time_series_utils.jl
@@ -25,3 +25,10 @@ end
 function time_series_metadata_to_data(ts_metadata::DeterministicMetadata)
     return ts_metadata.time_series_type
 end
+
+is_time_series_sub_type(::Type{<:TimeSeriesMetadata}, ::Type{<:TimeSeriesData}) = false
+is_time_series_sub_type(::Type{SingleTimeSeriesMetadata}, ::Type{StaticTimeSeries}) = true
+is_time_series_sub_type(::Type{DeterministicMetadata}, ::Type{AbstractDeterministic}) = true
+is_time_series_sub_type(::Type{DeterministicMetadata}, ::Type{Forecast}) = true
+is_time_series_sub_type(::Type{ProbabilisticMetadata}, ::Type{Forecast}) = true
+is_time_series_sub_type(::Type{ScenariosMetadata}, ::Type{Forecast}) = true


### PR DESCRIPTION
- Use PrettyTables to print system attributes and components in tables.
- Add show_components to display components of a specific type in a table.
- Add check_time_series_consistency to validate consistency across all SingleTimeSeries.

This may be incompatible with the current PSY version. There will be a companion PR forthcoming.