### PR TITLE
Replace TerminalLogger with ConsoleLogger

### DIFF
--- a/src/utils/logging.jl
+++ b/src/utils/logging.jl
@@ -263,7 +263,9 @@ function configure_logging(config::LoggingConfiguration)
 
     loggers = Vector{Logging.AbstractLogger}()
     if config.console
-        console_logger = TerminalLogger(config.console_stream, config.console_level)
+        # We could use TerminalLogger here but it renders messages as Markdown, and that
+        # can cause unexpected results, particularly with variable names and underscores.
+        console_logger = Logging.ConsoleLogger(config.console_stream, config.console_level)
         push!(loggers, console_logger)
     end
 


### PR DESCRIPTION
The TerminalLogger causes unexpected results when variables contain underscores. I think we're better off with just the ConsoleLogger. Progress logging is unaffected. Another option is to make TerminalLogger a kwarg, but I'm guessing that no one will ever use it. This is just a proposal; feel free to decline it.

![image](https://user-images.githubusercontent.com/9037606/139095066-c6cace24-54c8-445e-9934-28260f78ae87.png)
t.