### PR TITLE
Only log progress messages with ProgressLogger

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -25,7 +25,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [compat]
-CSV = "~0.8, 0.9"
+CSV = "0.9"
 DataFrames = "1"
 DataStructures = "~0.18"
 DocStringExtensions = "~0.8"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -6,7 +6,7 @@ InfrastructureSystems = "2cd47ed4-ca9b-11e9-27f2-ab636a7671f1"
 Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
 
 [compat]
-CSV = "~0.8"
+CSV = "~0.9"
 Documenter = "0.25"
 InfrastructureSystems = "1"
 julia = "^1.2"

--- a/src/utils/logging.jl
+++ b/src/utils/logging.jl
@@ -331,6 +331,7 @@ function Logging.handle_message(
 end
 
 function Logging.shouldlog(logger::FileLogger, level, _module, group, id)
+    level == ProgressLevel && return false
     return Logging.shouldlog(logger.logger, level, _module, group, id)
 end
 
@@ -553,7 +554,9 @@ function Logging.handle_message(
                         kwargs =
                             merge(Dict(kwargs), Dict(:num_suppressed => num_suppressed))
                     end
-                    # @show typeof(_logger)
+                    # Without this line, the ConsoleLogger would log progress messages if
+                    # its min_enabled_level was debug.
+                    level == ProgressLevel && !isa(_logger, ProgressLogger) && continue
                     Logging.handle_message(
                         _logger,
                         level,


### PR DESCRIPTION
If the user enabled debug messages for the console or file, progress
messages would also go to those loggers because the debug level is less
than the progress level.