### PR TITLE
Fail transform_single_time_series! on conflicting inputs

### DIFF
--- a/src/component.jl
+++ b/src/component.jl
@@ -492,6 +492,10 @@ function get_time_series_keys(component::InfrastructureSystemsComponent)
     return keys(get_time_series_container(component).data)
 end
 
+function list_time_series_metadata(component::InfrastructureSystemsComponent)
+    return collect(values(get_time_series_container(component).data))
+end
+
 function get_time_series_names(
     ::Type{T},
     component::InfrastructureSystemsComponent,

--- a/src/component.jl
+++ b/src/component.jl
@@ -638,6 +638,13 @@ function transform_single_time_series_internal!(
     for ts_metadata in values(container.data)
         if ts_metadata isa SingleTimeSeriesMetadata
             resolution = get_resolution(ts_metadata)
+            _params = _get_single_time_series_transformed_parameters(
+                ts_metadata,
+                T,
+                params.forecast_params.horizon,
+                params.forecast_params.interval,
+            )
+            check_params_compatibility(params, _params)
             new_metadata = DeterministicMetadata(
                 name = get_name(ts_metadata),
                 resolution = params.resolution,


### PR DESCRIPTION
This handles a case found by @claytonpbarrows where we created an invalid DeterministicSingleTimeSeries. It happened when the first SingleTimeSeries had a length one greater than the second.