### PR TITLE
Fix deserialization bug with Union{Nothing, Complex}

### DIFF
--- a/src/serialization.jl
+++ b/src/serialization.jl
@@ -239,6 +239,11 @@ deserialize(::Type{Complex{T}}, data::Dict) where {T} =
 
 deserialize(::Type{Vector{Symbol}}, data::Vector) = Symbol.(data)
 
+# This handles Union{Nothing, Complex} and possibly others.
+function deserialize(::Type{Union{Nothing, T}}, data::Dict) where {T <: Number}
+    return deserialize(T, data)
+end
+
 function serialize_julia_info()
     data = Dict{String, Any}("julia_version" => string(VERSION))
     io = IOBuffer()


### PR DESCRIPTION
This fixes a bug found by Sourabh when he had HybridSystem.interconnection_impedance set to a complex value. In all other deserialization cases it had been set to nothing.

I tested this with a PowerSystems test, which I'll add after this fix reaches a tagged version.