### PR TITLE
Fix bug where transform_single_time_series! fails

### DIFF
--- a/src/component.jl
+++ b/src/component.jl
@@ -727,7 +727,7 @@ function get_single_time_series_transformed_parameters(
         end
     end
 
-    throw(ArgumentError("component $(get_name(component)) does not have SingleTimeSeries"))
+    return
 end
 
 function _get_single_time_series_transformed_parameters(

--- a/src/system_data.jl
+++ b/src/system_data.jl
@@ -517,6 +517,10 @@ function transform_single_time_series!(
                 horizon,
                 interval,
             )
+            if params === nothing
+                # This component doesn't have SingleTimeSeries.
+                continue
+            end
             # This will throw if there is another forecast type with conflicting parameters.
             check_params_compatibility(data.time_series_params, params)
         end


### PR DESCRIPTION
This function will throw an exception if the first component that has time series does not have any time series of type SingleTimeSeries.