### PR TITLE
Improve dispatch of FlattenIteratorWrapper

### DIFF
--- a/src/utils/flatten_iterator_wrapper.jl
+++ b/src/utils/flatten_iterator_wrapper.jl
@@ -2,21 +2,22 @@
 """
 Wrapper around Iterators.Flatten to provide total length.
 """
-struct FlattenIteratorWrapper{T}
-    element_type::Type{T}
-    iter::Iterators.Flatten
+struct FlattenIteratorWrapper{T,I}
+    iter::Iterators.Flatten{I}
     length::Int
 end
 
-function FlattenIteratorWrapper(element_type::Type{T}, vals) where {T}
+function FlattenIteratorWrapper(::Type{T}, vals::I) where {T,I}
     len = isempty(vals) ? 0 : sum((length(x) for x in vals))
-    return FlattenIteratorWrapper(T, Iterators.Flatten(vals), len)
+    return FlattenIteratorWrapper{T,I}(Iterators.Flatten(vals), len)
 end
 
-Base.iterate(iter::FlattenIteratorWrapper) = Base.iterate(iter.iter)
-Base.iterate(iter::FlattenIteratorWrapper, state) = Base.iterate(iter.iter, state)
-Base.eltype(iter::FlattenIteratorWrapper) = iter.element_type
-
-function Base.length(iter::FlattenIteratorWrapper)
-    return iter.length
+Base.@propagate_inbounds function Base.iterate(
+    iter::FlattenIteratorWrapper{T,I},
+    state=()
+) where {T,I}
+    Base.iterate(iter.iter, state)
 end
+
+Base.eltype(::FlattenIteratorWrapper{T,I}) where {T,I} = T
+Base.length(iter::FlattenIteratorWrapper) = iter.length


### PR DESCRIPTION
YMMV, but encountered some dispatch issues with `get_components` sourced by dispatch on `FlattenIteratorWrapper`, presumably on `Base.iterate`. Usecase was PowerSystem with ~100,000 loads. 


Before,
```
BenchmarkTools.Trial: 323 samples with 1 evaluation.
 Range (min … max):  14.273 ms … 18.718 ms  ┊ GC (min … max): 0.00% … 19.03%
 Time  (median):     14.444 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   15.514 ms ±  1.623 ms  ┊ GC (mean ± σ):  6.71% ±  8.80%

  ▄█▆▂    ▂                                       ▄▄▄          
  ████▆▄▄▇█▅▄▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁████▅▁▁▁▁▆▇ ▆
  14.3 ms      Histogram: log(frequency) by time      18.6 ms <

 Memory estimate: 13.31 MiB, allocs estimate: 475707.
```

After,
```
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  442.667 μs … 525.167 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     444.500 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   445.731 μs ±   3.352 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▆▆  ▄▇█▇▅▂▃▄▂ ▂▅▆▅▄▁      ▁▁                                  ▂
  █████████████▇████████▇████████▇▇▆▇▇██▇▇█▇█▇▇▇▇██▇█▇██▆▇▇▆▆▅▆ █
  443 μs        Histogram: log(frequency) by time        459 μs <

 Memory estimate: 112 bytes, allocs estimate: 2.
```

I will admit that simple uses like `FlattenIteratorWrapper(Int, [1:1000000, 1:1000000])` didn't have an allocation problem to start with, but more complicated types sourced from `values(_components)` would cause issues (hence the YMMV note). 