### PR TITLE
Use smart copy of HDF5 files

### DIFF
--- a/src/time_series_storage.jl
+++ b/src/time_series_storage.jl
@@ -88,8 +88,7 @@ function serialize(storage::TimeSeriesStorage, file_path::AbstractString)
             return
         end
 
-        # The data is currently in a temp file, so we can just make a copy.
-        copy_file(get_file_path(storage), file_path)
+        copy_h5_file(get_file_path(storage), file_path)
     elseif storage isa InMemoryTimeSeriesStorage
         convert_to_hdf5(storage, file_path)
     else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@ import TerminalLoggers: TerminalLogger
 import TimeSeries
 import UUIDs
 import JSON3
+import HDF5
 using DataStructures: SortedDict
 using DataFrames
 using Random


### PR DESCRIPTION
The original code used a filesystem copy operation to copy HDF5 files with time series data. That was inefficient because it copied unused space that resulted from deleting time series arrays.

This commit uses the HDF5 copy_object function to avoid copying that unused space.

Fixes https://github.com/NREL-SIIP/PowerSystems.jl/issues/933