### PR TITLE
Log warning instead throwing an exception to handle PowerSystems upgrade from 1.x to 2.x

### DIFF
--- a/src/validation.jl
+++ b/src/validation.jl
@@ -62,11 +62,8 @@ function get_field_descriptor(struct_descriptor::Dict, fieldname::AbstractString
         end
     end
 
-    throw(
-        DataFormatError(
-            "field $fieldname does not exist in $(struct_descriptor["struct_name"]) validation config",
-        ),
-    )
+    @warn "field $fieldname does not exist in $(struct_descriptor["struct_name"]) validation config"
+    return
 end
 
 function validate_fields(
@@ -91,7 +88,7 @@ function validate_fields(
             end
         else
             field_descriptor = get_field_descriptor(struct_descriptor, string(field_name))
-            if !haskey(field_descriptor, "valid_range")
+            if isnothing(field_descriptor) || !haskey(field_descriptor, "valid_range")
                 continue
             end
             valid_range = field_descriptor["valid_range"]


### PR DESCRIPTION
The code was throwing an exception if a struct field was not present in a validation descriptor. This failed if a PowerSystems 1.x system was deserialized with 2.x code because some structs have new fields that were not part of the validation descriptor.

Fixes https://github.com/NREL-SIIP/PowerSystems.jl/issues/974

We did validate that the patch fixes the original issue.