### PR TITLE
Check ext serialization

### DIFF
--- a/src/internal.jl
+++ b/src/internal.jl
@@ -98,7 +98,7 @@ function serialize(internal::InfrastructureSystemsInternal)
             if !is_ext_valid_for_serialization(val)
                 error(
                     "system or component with uuid=$(internal.uuid) has a value in ext " *
-                    "that cannot be serialized"
+                    "that cannot be serialized",
                 )
             end
         end

--- a/src/internal.jl
+++ b/src/internal.jl
@@ -94,6 +94,14 @@ function serialize(internal::InfrastructureSystemsInternal)
         else
             val = serialize(val)
         end
+        if field == :ext
+            if !is_ext_valid_for_serialization(val)
+                error(
+                    "system or component with uuid=$(internal.uuid) has a value in ext " *
+                    "that cannot be serialized"
+                )
+            end
+        end
         data[string(field)] = val
     end
 

--- a/src/serialization.jl
+++ b/src/serialization.jl
@@ -287,9 +287,9 @@ function is_ext_valid_for_serialization(value)
 
     if !is_valid
         @error "Failed to serialize an 'ext' value. Please ensure that the " *
-            "contents follow the rules provided in the documentation. Generally, only " *
-            "basic types are allowed - strings and numbers and arrays, dictionaries, and " *
-            "structs of those." value
+               "contents follow the rules provided in the documentation. Generally, only " *
+               "basic types are allowed - strings and numbers and arrays, dictionaries, and " *
+               "structs of those." value
     end
 
     return is_valid

--- a/src/serialization.jl
+++ b/src/serialization.jl
@@ -271,3 +271,26 @@ function serialize_julia_info()
     data["package_info"] = String(take!(io))
     return data
 end
+
+"""
+Perform a test to see if JSON3 can convert this value so that the code can give the user a
+a comprehensible corrective action.
+"""
+function is_ext_valid_for_serialization(value)
+    isnothing(value) && return true
+    is_valid = true
+    try
+        JSON3.write(value)
+    catch
+        is_valid = false
+    end
+
+    if !is_valid
+        @error "Failed to serialize an 'ext' value. Please ensure that the " *
+            "contents follow the rules provided in the documentation. Generally, only " *
+            "basic types are allowed - strings and numbers and arrays, dictionaries, and " *
+            "structs of those." value
+    end
+
+    return is_valid
+end

--- a/src/validation.jl
+++ b/src/validation.jl
@@ -62,11 +62,8 @@ function get_field_descriptor(struct_descriptor::Dict, fieldname::AbstractString
         end
     end
 
-    throw(
-        DataFormatError(
-            "field $fieldname does not exist in $(struct_descriptor["struct_name"]) validation config",
-        ),
-    )
+    @warn "field $fieldname does not exist in $(struct_descriptor["struct_name"]) validation config"
+    return
 end
 
 function validate_fields(
@@ -91,7 +88,7 @@ function validate_fields(
             end
         else
             field_descriptor = get_field_descriptor(struct_descriptor, string(field_name))
-            if !haskey(field_descriptor, "valid_range")
+            if isnothing(field_descriptor) || !haskey(field_descriptor, "valid_range")
                 continue
             end
             valid_range = field_descriptor["valid_range"]

--- a/test/test_serialization.jl
+++ b/test/test_serialization.jl
@@ -114,3 +114,23 @@ end
     @test occursin(" ", text)
     IS.deserialize(IS.TestComponent, JSON3.read(text, Dict)) == component
 end
+
+@testset "Test ext serialization" begin
+    @test IS.is_ext_valid_for_serialization(nothing)
+    @test IS.is_ext_valid_for_serialization(1)
+    @test IS.is_ext_valid_for_serialization("test")
+    @test IS.is_ext_valid_for_serialization([1, 2, 3])
+    @test IS.is_ext_valid_for_serialization(Dict("a" => 1, "b" => 2, "c" => 3))
+
+    struct MyType
+        func::Function
+    end
+
+    @test(
+        @test_logs(
+            (:error, r"only basic types are allowed"),
+            match_mode = :any,
+            !IS.is_ext_valid_for_serialization(MyType(println))
+        )
+    )
+end


### PR DESCRIPTION
Add a serialization check for ext fields

Users would get incomprehensible error messages if they tried to
serialize systems with invalid values stored in ext fields. This gives a
concise corrective action.

Fixes https://github.com/NREL-SIIP/PowerSystems.jl/issues/971
