### PR TITLE
More verbose when duplicated name component is added

### DIFF
--- a/src/components.jl
+++ b/src/components.jl
@@ -39,7 +39,7 @@ function _add_component!(
     if !haskey(components.data, T)
         components.data[T] = Dict{String, T}()
     elseif haskey(components.data[T], component_name)
-        throw(ArgumentError("$(component_name) is already stored for type $T"))
+        throw(ArgumentError("Component name $(component_name) is already stored for type $T"))
     end
 
     !skip_validation && check_component(components, component)


### PR DESCRIPTION
Improve verbosity when error duplicated name.

From

```julia
        throw(ArgumentError("$(component_name) is already stored for type $T"))
```

to

```julia
        throw(ArgumentError("Component name $(component_name) is already stored for type $T"))
```