### PR TITLE
fix time series removal order bug

### DIFF
--- a/src/time_series_metadata_store.jl
+++ b/src/time_series_metadata_store.jl
@@ -1164,7 +1164,11 @@ function list_metadata(
         SELECT metadata_uuid
         FROM $ASSOCIATIONS_TABLE_NAME
         $where_clause
+        ORDER BY time_series_type
     """
+    # ORDER BY clause: DeterministicSingleTimeSeries refers to the data of a SingleTimeSeries,
+    # so must remove the Deterministic one first, else clear_time_series! errors.
+    # D < S, so alphabetical ordering works.
     table = Tables.rowtable(_execute_cached(store, query, params))
     return [store.metadata_uuids[Base.UUID(x.metadata_uuid)] for x in table]
 end


### PR DESCRIPTION
Fix the bug that makes the `remove_components!` function I wrote [here](https://github.com/NREL-Sienna/PowerSimulations.jl/pull/1402#discussion_r2414086315) necessary.