### PR TITLE
Add tests for _process_timestamps

### DIFF
--- a/src/Optimization/optimization_problem_results.jl
+++ b/src/Optimization/optimization_problem_results.jl
@@ -400,11 +400,16 @@ function _process_timestamps(
         requested_range = findall(x -> x >= start_time, timestamps)
         def_len = length(requested_range)
     end
-    len = len === nothing ? def_len : len
-    if len > def_len
+    actual_len = if len === nothing
+        def_len
+    elseif len < 0
+        throw(InvalidValue("len cannot be negative: $len"))
+    elseif len > def_len
         throw(InvalidValue("requested results have less than $len values"))
+    else
+        len
     end
-    timestamp_ids = requested_range[1:len]
+    timestamp_ids = requested_range[1:actual_len]
     return timestamp_ids, timestamps[timestamp_ids]
 end
 


### PR DESCRIPTION
This is a companion PR to #494 

@jd-lara Can you confirm that the logic [here](https://github.com/NREL-Sienna/InfrastructureSystems.jl/blob/4d4645fcf9e0759cc4aaa6e130fb21bd1f017077/src/Optimization/optimization_problem_results.jl#L397) is correct? I didn't add a test for it.