### PR TITLE
Unify the get_time_series interfaces

### DIFF
--- a/src/time_series_cache.jl
+++ b/src/time_series_cache.jl
@@ -45,8 +45,8 @@ function get_time_series_array!(cache::TimeSeriesCache, timestamp::Dates.DateTim
     len = _get_length(cache)
     ta = get_time_series_array(
         _get_component(cache),
-        _get_time_series(cache),
-        timestamp;
+        _get_time_series(cache);
+        start_time = timestamp,
         len = len,
         ignore_scaling_factors = _get_ignore_scaling_factors(cache),
     )
@@ -260,8 +260,8 @@ function ForecastCache(
     )
     vals = get_time_series_values(
         component,
-        ts,
-        start_time;
+        ts;
+        start_time = start_time,
         len = get_horizon_count(ts_metadata),
     )
     row_size = _get_row_size(vals)
@@ -375,7 +375,7 @@ function StaticTimeSeriesCache(
 
     # Get an instance to assess data size.
     ts = get_time_series(T, component, name; start_time = start_time, len = 1)
-    vals = get_time_series_values(component, ts, start_time; len = 1)
+    vals = get_time_series_values(component, ts; start_time = start_time, len = 1)
     row_size = _get_row_size(vals)
 
     if row_size > cache_size_bytes

--- a/test/test_time_series_cache.jl
+++ b/test/test_time_series_cache.jl
@@ -20,8 +20,9 @@
     for (i, ta) in enumerate(cache)
         it = initial_times[i]
         @test TimeSeries.timestamp(ta) ==
-              IS.get_time_series_timestamps(component, forecast, it)
-        @test TimeSeries.values(ta) == IS.get_time_series_values(component, forecast, it)
+              IS.get_time_series_timestamps(component, forecast; start_time = it)
+        @test TimeSeries.values(ta) ==
+              IS.get_time_series_values(component, forecast; start_time = it)
     end
 
     IS.reset!(cache)
@@ -29,8 +30,9 @@
         ta = IS.get_next_time_series_array!(cache)
         @test first(TimeSeries.timestamp(ta)) == it
         @test TimeSeries.timestamp(ta) ==
-              IS.get_time_series_timestamps(component, forecast, it)
-        @test TimeSeries.values(ta) == IS.get_time_series_values(component, forecast, it)
+              IS.get_time_series_timestamps(component, forecast; start_time = it)
+        @test TimeSeries.values(ta) ==
+              IS.get_time_series_values(component, forecast; start_time = it)
     end
     @test IS.get_next_time(cache) === nothing
 
@@ -40,16 +42,18 @@
     for (i, ta) in enumerate(cache)
         it = initial_times[i]
         @test TimeSeries.timestamp(ta) ==
-              IS.get_time_series_timestamps(component, forecast, it)
-        @test TimeSeries.values(ta) == IS.get_time_series_values(component, forecast, it)
+              IS.get_time_series_timestamps(component, forecast; start_time = it)
+        @test TimeSeries.values(ta) ==
+              IS.get_time_series_values(component, forecast; start_time = it)
     end
 
     IS.reset!(cache)
     for it in initial_times
         ta = IS.get_next_time_series_array!(cache)
         @test TimeSeries.timestamp(ta) ==
-              IS.get_time_series_timestamps(component, forecast, it)
-        @test TimeSeries.values(ta) == IS.get_time_series_values(component, forecast, it)
+              IS.get_time_series_timestamps(component, forecast; start_time = it)
+        @test TimeSeries.values(ta) ==
+              IS.get_time_series_values(component, forecast; start_time = it)
     end
 
     # Start at an offset.
@@ -62,8 +66,9 @@
     for (i, ta) in enumerate(cache)
         it = initial_times[i + 24]
         @test TimeSeries.timestamp(ta) ==
-              IS.get_time_series_timestamps(component, forecast, it)
-        @test TimeSeries.values(ta) == IS.get_time_series_values(component, forecast, it)
+              IS.get_time_series_timestamps(component, forecast; start_time = it)
+        @test TimeSeries.values(ta) ==
+              IS.get_time_series_values(component, forecast; start_time = it)
     end
 
     # Test caching internals.
@@ -74,17 +79,18 @@
         ta = IS.get_next_time_series_array!(cache)
         @test IS._get_last_cached_time(cache) == initial_times[5]
         @test TimeSeries.timestamp(ta) ==
-              IS.get_time_series_timestamps(component, forecast, it)
-        @test TimeSeries.values(ta) == IS.get_time_series_values(component, forecast, it)
+              IS.get_time_series_timestamps(component, forecast; start_time = it)
+        @test TimeSeries.values(ta) ==
+              IS.get_time_series_values(component, forecast; start_time = it)
     end
 
     # The next access should trigger a read.
     ta = IS.get_next_time_series_array!(cache)
     @test IS._get_last_cached_time(cache) == initial_times[10]
     @test TimeSeries.timestamp(ta) ==
-          IS.get_time_series_timestamps(component, forecast, initial_times[6])
+          IS.get_time_series_timestamps(component, forecast; start_time = initial_times[6])
     @test TimeSeries.values(ta) ==
-          IS.get_time_series_values(component, forecast, initial_times[6])
+          IS.get_time_series_values(component, forecast; start_time = initial_times[6])
     @test IS.get_next_time(cache) == initial_times[7]
 end
 
@@ -115,16 +121,22 @@ end
     for (i, ta) in enumerate(cache)
         it = initial_timestamp + (i - 1) * resolution
         @test TimeSeries.timestamp(ta) ==
-              IS.get_time_series_timestamps(component, ts, it; len = 1)
-        @test TimeSeries.values(ta) == IS.get_time_series_values(component, ts, it; len = 1)
+              IS.get_time_series_timestamps(component, ts; start_time = it, len = 1)
+        @test TimeSeries.values(ta) ==
+              IS.get_time_series_values(component, ts; start_time = it, len = 1)
     end
 
     ta = IS.get_next_time_series_array!(cache)
     @test first(TimeSeries.timestamp(ta)) == initial_timestamp
     @test TimeSeries.timestamp(ta) ==
-          IS.get_time_series_timestamps(component, ts, initial_timestamp; len = 1)
+          IS.get_time_series_timestamps(
+        component,
+        ts;
+        start_time = initial_timestamp,
+        len = 1,
+    )
     @test TimeSeries.values(ta) ==
-          IS.get_time_series_values(component, ts, initial_timestamp; len = 1)
+          IS.get_time_series_values(component, ts; start_time = initial_timestamp, len = 1)
 
     # Iterate over all initial times with custom cache size.
     cache_size_bytes = 96
@@ -145,8 +157,9 @@ end
     for (i, ta) in enumerate(cache)
         it = initial_timestamp + (i - 1) * resolution
         @test TimeSeries.timestamp(ta) ==
-              IS.get_time_series_timestamps(component, ts, it; len = 1)
-        @test TimeSeries.values(ta) == IS.get_time_series_values(component, ts, it; len = 1)
+              IS.get_time_series_timestamps(component, ts; start_time = it, len = 1)
+        @test TimeSeries.values(ta) ==
+              IS.get_time_series_values(component, ts; start_time = it, len = 1)
     end
 
     IS.reset!(cache)
@@ -154,8 +167,9 @@ end
         ta = IS.get_next_time_series_array!(cache)
         it = initial_timestamp + (i - 1) * resolution
         @test TimeSeries.timestamp(ta) ==
-              IS.get_time_series_timestamps(component, ts, it; len = 1)
-        @test TimeSeries.values(ta) == IS.get_time_series_values(component, ts, it; len = 1)
+              IS.get_time_series_timestamps(component, ts; start_time = it, len = 1)
+        @test TimeSeries.values(ta) ==
+              IS.get_time_series_values(component, ts; start_time = it, len = 1)
     end
 
     cache_size_bytes = 96
@@ -175,8 +189,9 @@ end
         ta = IS.get_next_time_series_array!(cache)
         it = start_time + (i - 1) * resolution
         @test TimeSeries.timestamp(ta) ==
-              IS.get_time_series_timestamps(component, ts, it; len = 1)
-        @test TimeSeries.values(ta) == IS.get_time_series_values(component, ts, it; len = 1)
+              IS.get_time_series_timestamps(component, ts; start_time = it, len = 1)
+        @test TimeSeries.values(ta) ==
+              IS.get_time_series_values(component, ts; start_time = it, len = 1)
     end
 end
 
@@ -209,9 +224,13 @@ end
 
     for (i, ta) in enumerate(cache)
         @test TimeSeries.timestamp(ta) ==
-              IS.get_time_series_timestamps(component, forecast, initial_times[i])
+              IS.get_time_series_timestamps(
+            component,
+            forecast;
+            start_time = initial_times[i],
+        )
         @test TimeSeries.values(ta) ==
-              IS.get_time_series_values(component, forecast, initial_times[i])
+              IS.get_time_series_values(component, forecast; start_time = initial_times[i])
     end
 end
 
@@ -240,8 +259,9 @@ end
     for (i, ta) in enumerate(cache)
         it = initial_times[i]
         @test TimeSeries.timestamp(ta) ==
-              IS.get_time_series_timestamps(component, forecast, it)
-        @test TimeSeries.values(ta) == IS.get_time_series_values(component, forecast, it)
+              IS.get_time_series_timestamps(component, forecast; start_time = it)
+        @test TimeSeries.values(ta) ==
+              IS.get_time_series_values(component, forecast; start_time = it)
     end
 end
 
@@ -264,14 +284,15 @@ end
     @test length(cache) == cache.common.num_iterations == 168
 
     for it in initial_times
-        expected_timestamps = IS.get_time_series_timestamps(component, forecast, it)
-        expected_values = IS.get_time_series_values(component, forecast, it)
+        expected_timestamps =
+            IS.get_time_series_timestamps(component, forecast; start_time = it)
+        expected_values = IS.get_time_series_values(component, forecast; start_time = it)
         for _ in 1:2
             ta = IS.get_time_series_array!(cache, it)
             @test TimeSeries.timestamp(ta) ==
-                  IS.get_time_series_timestamps(component, forecast, it)
+                  IS.get_time_series_timestamps(component, forecast; start_time = it)
             @test TimeSeries.values(ta) ==
-                  IS.get_time_series_values(component, forecast, it)
+                  IS.get_time_series_values(component, forecast; start_time = it)
         end
     end
 


### PR DESCRIPTION
This PR does two things:
- Add support for using a TimeSeriesKey to retrieve a time series using get_time_series_array|values|timestamps. This unifies the interface. `add_time_series!` returns a key which the user can use to retrieve the time series object later - with any of the interfaces. We currently only support this with `get_time_series`.
- Change all interfaces to use start_time and len ask wargs instead of optional, positional arguments. All function calls will be predictable.