### PR TITLE
define 2-arg `hash` to eliminate method invalidations

### DIFF
--- a/src/function_data.jl
+++ b/src/function_data.jl
@@ -325,7 +325,7 @@ Base.:(==)(a::T, b::T) where {T <: FunctionData} = double_equals_from_fields(a, 
 
 Base.isequal(a::T, b::T) where {T <: FunctionData} = isequal_from_fields(a, b)
 
-Base.hash(a::FunctionData) = hash_from_fields(a)
+Base.hash(a::FunctionData, h::UInt) = hash_from_fields(a, h)
 
 function _slope_convexity_check(slopes::Vector{Float64})
     for ix in 1:(length(slopes) - 1)

--- a/src/production_variable_cost_curve.jl
+++ b/src/production_variable_cost_curve.jl
@@ -27,7 +27,7 @@ Base.:(==)(a::T, b::T) where {T <: ProductionVariableCostCurve} =
 Base.isequal(a::T, b::T) where {T <: ProductionVariableCostCurve} =
     isequal_from_fields(a, b)
 
-Base.hash(a::ProductionVariableCostCurve) = hash_from_fields(a)
+Base.hash(a::ProductionVariableCostCurve, h::UInt) = hash_from_fields(a, h)
 
 """
 $(TYPEDEF)

--- a/src/value_curve.jl
+++ b/src/value_curve.jl
@@ -103,7 +103,7 @@ Base.:(==)(a::T, b::T) where {T <: ValueCurve} = double_equals_from_fields(a, b)
 
 Base.isequal(a::T, b::T) where {T <: ValueCurve} = isequal_from_fields(a, b)
 
-Base.hash(a::ValueCurve) = hash_from_fields(a)
+Base.hash(a::ValueCurve, h::UInt) = hash_from_fields(a, h)
 
 "Get an `InputOutputCurve` representing `f(x) = 0`"
 Base.zero(::Union{InputOutputCurve, Type{InputOutputCurve}}) =


### PR DESCRIPTION
I don't fully understand why, but the compiler dislikes it when we only define the 1-argument `hash` and not the 2-argument. I defined the 2-arg one, which makes the 1-argument unnecessary (it'll default to `hash(foo, 0)`).