### PR TITLE
Switch to import InfrastructureSystem as IS

### DIFF
--- a/docs/src/style.md
+++ b/docs/src/style.md
@@ -33,6 +33,12 @@
   - When writing a module locate all the exports in the main module file.
   - Please include a copy of [this .gitignore file](https://github.com/NREL-Sienna/InfrastructureSystems.jl/blob/main/.gitignore)
 
+## Module Aliases
+
+Use the `import X as Y` syntax instead of `const Y = X` when creating module aliases.
+
+Since Julia 1.6, language servers will recognize `import X as Y` where they fail to recognize `const` aliases.
+
 ## Comments
 
   - Use comments to describe non-obvious or non-trivial aspects of code.

--- a/src/Optimization/Optimization.jl
+++ b/src/Optimization/Optimization.jl
@@ -12,8 +12,7 @@ import DataFrames
 import DataFrames: DataFrame, innerjoin, select, select!
 import DataFramesMeta: @chain, @combine, @subset, @transform
 
-import ..InfrastructureSystems
-const IS = InfrastructureSystems
+import ..InfrastructureSystems as IS
 
 import ..InfrastructureSystems:
     @scoped_enum,

--- a/src/Simulation/Simulation.jl
+++ b/src/Simulation/Simulation.jl
@@ -3,8 +3,7 @@
 """
 module Simulation
 
-import ..InfrastructureSystems
-const IS = InfrastructureSystems
+import ..InfrastructureSystems as IS
 
 import ..InfrastructureSystems:
     @scoped_enum

--- a/test/InfrastructureSystemsTests.jl
+++ b/test/InfrastructureSystemsTests.jl
@@ -16,6 +16,7 @@ using ProgressLogging
 import SQLite
 
 import InfrastructureSystems
+import InfrastructureSystems as IS
 
 import Aqua
 Aqua.test_unbound_args(InfrastructureSystems)
@@ -24,7 +25,6 @@ Aqua.test_ambiguities(InfrastructureSystems)
 Aqua.test_stale_deps(InfrastructureSystems)
 Aqua.test_deps_compat(InfrastructureSystems)
 
-const IS = InfrastructureSystems
 const BASE_DIR =
     abspath(joinpath(dirname(Base.find_package("InfrastructureSystems")), ".."))
 const DATA_DIR = joinpath(BASE_DIR, "test", "data")
@@ -56,9 +56,9 @@ function run_tests(args...; kwargs...)
             config = IS.LoggingConfiguration(logging_config_filename)
         else
             config = IS.LoggingConfiguration(;
-                filename = LOG_FILE,
-                file_level = get_logging_level_from_env("SIENNA_FILE_LOG_LEVEL", "Info"),
-                console_level = get_logging_level_from_env(
+                filename=LOG_FILE,
+                file_level=get_logging_level_from_env("SIENNA_FILE_LOG_LEVEL", "Info"),
+                console_level=get_logging_level_from_env(
                     "SIENNA_CONSOLE_LOG_LEVEL",
                     "Error",
                 ),

--- a/test/test_model_internal.jl
+++ b/test/test_model_internal.jl
@@ -1,5 +1,5 @@
 import InfrastructureSystems.Optimization: ModelInternal
-const IS = InfrastructureSystems
+import InfrastructureSystems as IS
 @testset "Test Model Internal" begin
     internal = ModelInternal(
         MockContainer(),

--- a/test/test_optimization_container_keys.jl
+++ b/test/test_optimization_container_keys.jl
@@ -5,7 +5,7 @@ import InfrastructureSystems.Optimization:
     ExpressionKey,
     ParameterKey,
     InitialConditionKey
-const IS = InfrastructureSystems
+import InfrastructureSystems as IS
 @testset "Test optimization container keys" begin
     var_key = VariableKey(MockVariable, IS.TestComponent)
     @test IS.Optimization.encode_key(var_key) ==

--- a/test/test_optimization_results.jl
+++ b/test/test_optimization_results.jl
@@ -8,7 +8,7 @@ import InfrastructureSystems.Optimization:
 import Dates:
     DateTime,
     Millisecond
-const IS = InfrastructureSystems
+import InfrastructureSystems as IS
 
 @testset "Test OptimizationProblemResults long format" begin
     base_power = 10.0
@@ -124,8 +124,8 @@ const IS = InfrastructureSystems
     var_res2 = read_variable(
         opt_res1,
         var_key1;
-        start_time = DateTime("2024-01-01T01:00:00"),
-        len = 2,
+        start_time=DateTime("2024-01-01T01:00:00"),
+        len=2,
     )
     @test @rsubset(var_res2, :name == "c1")[!, :value] == [2.0, 3.0]
     @test @rsubset(var_res2, :name == "c2")[!, :value] == [6.0, 7.0]
@@ -133,13 +133,13 @@ const IS = InfrastructureSystems
     var_res2 = read_variable(
         opt_res1,
         var_key2;
-        start_time = DateTime("2024-01-01T01:00:00"),
-        len = 2,
+        start_time=DateTime("2024-01-01T01:00:00"),
+        len=2,
     )
     @test @rsubset(var_res2, :name == "c1")[!, :value] == [20.0, 30.0]
     @test @rsubset(var_res2, :name == "c2")[!, :value] == [60.0, 70.0]
 
-    var_res = read_variable(opt_res1, var_key2; table_format = IS.TableFormat.WIDE)
+    var_res = read_variable(opt_res1, var_key2; table_format=IS.TableFormat.WIDE)
     @test var_res[!, :c1] == [10.0, 20.0, 30.0, 40.0]
     @test var_res[!, :c2] == [50.0, 60.0, 70.0, 80.0]
 

--- a/test/test_optimizer_stats.jl
+++ b/test/test_optimizer_stats.jl
@@ -1,5 +1,5 @@
 import InfrastructureSystems.Optimization: OptimizerStats
-const IS = InfrastructureSystems
+import InfrastructureSystems as IS
 @testset "Test OptimizerStats" begin
     empty_stats = OptimizerStats()
     @test isa(IS.Optimization.get_column_names(OptimizerStats), Tuple{Vector{String}})


### PR DESCRIPTION
If you use `import InfrastructureSystems as IS`, then the LSP hover info works. There may be problems with files in `test/`, where the language server fails to analyze anything.

https://docs.julialang.org/en/v1/manual/modules/#Renaming-with-as