### PR TITLE
Add docstrings to all exported symbols

### DIFF
--- a/src/components.jl
+++ b/src/components.jl
@@ -347,6 +347,9 @@ function iterate_components(components::Components)
     return iterate_container(components)
 end
 
+"""
+Return the total number of components stored.
+"""
 function get_num_components(components::Components)
     return get_num_members(components)
 end

--- a/src/forecasts.jl
+++ b/src/forecasts.jl
@@ -19,6 +19,12 @@ abstract type Forecast <: TimeSeriesData end
 
 Base.length(ts::Forecast) = get_count(ts)
 
+"""
+Supertype for all deterministic forecast time series.
+
+Concrete subtypes include [`Deterministic`](@ref) and
+[`DeterministicSingleTimeSeries`](@ref).
+"""
 abstract type AbstractDeterministic <: Forecast end
 
 function check_time_series_data(forecast::Forecast)

--- a/src/function_data/function_data.jl
+++ b/src/function_data/function_data.jl
@@ -1,3 +1,9 @@
+"""
+Supertype for all function data representations used in cost modeling.
+
+Concrete subtypes include [`LinearFunctionData`](@ref), [`QuadraticFunctionData`](@ref),
+[`PiecewiseLinearData`](@ref), and [`PiecewiseStepData`](@ref).
+"""
 abstract type FunctionData end
 
 """

--- a/src/internal.jl
+++ b/src/internal.jl
@@ -5,6 +5,15 @@ abstract type UnitsData end
 
 @scoped_enum(UnitSystem, SYSTEM_BASE = 0, DEVICE_BASE = 1, NATURAL_UNITS = 2,)
 
+@doc """
+Unit system for component data values.
+
+# Values
+- `SYSTEM_BASE`: Per-unit values on the system base power
+- `DEVICE_BASE`: Per-unit values on the device base power
+- `NATURAL_UNITS`: Values in natural units (e.g., MW, MVAR)
+""" UnitSystem
+
 @kwdef mutable struct SystemUnitsSettings <: UnitsData
     base_value::Float64
     unit_system::UnitSystem

--- a/src/production_variable_cost_curve.jl
+++ b/src/production_variable_cost_curve.jl
@@ -1,3 +1,9 @@
+"""
+Supertype for production variable cost curve representations, parameterized by
+a [`ValueCurve`](@ref) type.
+
+Concrete subtypes include [`CostCurve`](@ref) and [`FuelCurve`](@ref).
+"""
 abstract type ProductionVariableCostCurve{T <: ValueCurve} end
 
 serialize(val::ProductionVariableCostCurve) = serialize_struct(val)

--- a/src/time_series_parser.jl
+++ b/src/time_series_parser.jl
@@ -154,6 +154,13 @@ end
 
 @scoped_enum NormalizationTypes MAX = 1
 
+@doc """
+Types of normalization that can be applied to time series data.
+
+# Values
+- `MAX`: Normalize by the maximum value in the time series
+""" NormalizationTypes
+
 const NormalizationFactor = Union{Float64, NormalizationTypes}
 
 function handle_normalization_factor(

--- a/src/time_series_storage.jl
+++ b/src/time_series_storage.jl
@@ -18,6 +18,14 @@ const DEFAULT_COMPRESSION = false
 
 @scoped_enum(CompressionTypes, BLOSC = 0, DEFLATE = 1,)
 
+@doc """
+HDF5 compression algorithm types for time series storage.
+
+# Values
+- `BLOSC`: Blosc compression (fast, general-purpose)
+- `DEFLATE`: Deflate/zlib compression
+""" CompressionTypes
+
 """
     CompressionSettings(enabled, type, level, shuffle)
 

--- a/src/utils/logging.jl
+++ b/src/utils/logging.jl
@@ -145,6 +145,11 @@ function LoggingConfiguration(config_filename)
     return LoggingConfiguration(; Dict(Symbol(k) => v for (k, v) in config)...)
 end
 
+"""
+Create a logging configuration file from the default template.
+
+Pass `force = true` to overwrite an existing file.
+"""
 function make_logging_config_file(filename = "logging_config.toml"; force = false)
     cp(SIENNA_LOGGING_CONFIG_FILENAME, filename; force = force)
     println("Created $filename")


### PR DESCRIPTION
## Summary
- Adds docstrings for 8 exported types/functions that were missing documentation
- Types: `AbstractDeterministic`, `FunctionData`, `ProductionVariableCostCurve`, `CompressionTypes`, `NormalizationTypes`, `UnitSystem`
- Functions: `get_num_components`, `make_logging_config_file`
- Uses `@doc` macro for `@scoped_enum` types (they expand to module definitions that can't use standard preceding docstrings)

## Test plan
- [x] Docs build passes with no new errors
- [x] Formatter run clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)