### PR TITLE
a few more renames

### DIFF
--- a/src/Optimization/optimization_container_types.jl
+++ b/src/Optimization/optimization_container_types.jl
@@ -8,21 +8,21 @@ abstract type ParameterType <: OptimizationKeyType end
 abstract type InitialConditionType <: OptimizationKeyType end
 abstract type ExpressionType <: OptimizationKeyType end
 
-convert_result_to_natural_units(::Type{<:VariableType}) = false
-convert_result_to_natural_units(::Type{<:ConstraintType}) = false
-convert_result_to_natural_units(::Type{<:AuxVariableType}) = false
-convert_result_to_natural_units(::Type{<:ExpressionType}) = false
-convert_result_to_natural_units(::Type{<:InitialConditionType}) = ArgumentError(
-    "Initial conditions aren't written to results store: this shouldn't be called.",
+convert_output_to_natural_units(::Type{<:VariableType}) = false
+convert_output_to_natural_units(::Type{<:ConstraintType}) = false
+convert_output_to_natural_units(::Type{<:AuxVariableType}) = false
+convert_output_to_natural_units(::Type{<:ExpressionType}) = false
+convert_output_to_natural_units(::Type{<:InitialConditionType}) = ArgumentError(
+    "Initial conditions aren't written to output store: this shouldn't be called.",
 )
-convert_result_to_natural_units(::Type{<:ParameterType}) = false
+convert_output_to_natural_units(::Type{<:ParameterType}) = false
 
 should_write_resulting_value(::Type{<:VariableType}) = true
 should_write_resulting_value(::Type{<:ConstraintType}) = true
 should_write_resulting_value(::Type{<:AuxVariableType}) = true
 should_write_resulting_value(::Type{<:ExpressionType}) = false
 should_write_resulting_value(::Type{<:InitialConditionType}) = ArgumentError(
-    "Initial conditions aren't written to results store: this shouldn't be called.",
+    "Initial conditions aren't written to output store: this shouldn't be called.",
 )
 # TODO: Piecewise linear parameter are broken to write
 should_write_resulting_value(::Type{<:ParameterType}) = false

--- a/src/outputs.jl
+++ b/src/outputs.jl
@@ -2,8 +2,8 @@
 To implement a sub-type of this you need to implement the methods below.
 """
 abstract type Outputs end
-function get_results_base_power(r::T) where {T <: Outputs}
-    error("get_results_base_power must be implemented for $T")
+function get_outputs_base_power(r::T) where {T <: Outputs}
+    error("get_outputs_base_power must be implemented for $T")
 end
 
 function get_variables(r::T) where {T <: Outputs}
@@ -26,8 +26,8 @@ function get_timestamp(r::T) where {T <: Outputs}
     error("get_timestamp must be implemented for $T")
 end
 
-function write_results(r::T) where {T <: Outputs}
-    error("write_results must be implemented for $T")
+function write_outputs(r::T) where {T <: Outputs}
+    error("write_output must be implemented for $T")
 end
 
 # Must override if your concrete Outputs subtype has the notion of an associated source data

--- a/test/optimization.jl
+++ b/test/optimization.jl
@@ -16,9 +16,9 @@ struct MockStoreParams <: IS.Optimization.AbstractModelStoreParams
 end
 
 # Extend utility functions for custom types
-IS.Optimization.convert_result_to_natural_units(::Type{MockVariable2}) = true
+IS.Optimization.convert_output_to_natural_units(::Type{MockVariable2}) = true
 IS.Optimization.should_write_resulting_value(::Type{MockVariable2}) = false
-IS.Optimization.convert_result_to_natural_units(::Type{MockExpression2}) = true
+IS.Optimization.convert_output_to_natural_units(::Type{MockExpression2}) = true
 IS.Optimization.should_write_resulting_value(::Type{MockExpression2}) = false
 
 @testset "IS.Optimization abstract types" begin
@@ -37,21 +37,21 @@ end
 
 @testset "IS.Optimization utility functions" begin
     # Test default values
-    @test IS.Optimization.convert_result_to_natural_units(MockVariable) == false
+    @test IS.Optimization.convert_output_to_natural_units(MockVariable) == false
     @test IS.Optimization.should_write_resulting_value(MockVariable) == true
-    @test IS.Optimization.convert_result_to_natural_units(MockConstraint) == false
+    @test IS.Optimization.convert_output_to_natural_units(MockConstraint) == false
     @test IS.Optimization.should_write_resulting_value(MockConstraint) == true
-    @test IS.Optimization.convert_result_to_natural_units(MockAuxVariable) == false
+    @test IS.Optimization.convert_output_to_natural_units(MockAuxVariable) == false
     @test IS.Optimization.should_write_resulting_value(MockAuxVariable) == true
-    @test IS.Optimization.convert_result_to_natural_units(MockExpression) == false
+    @test IS.Optimization.convert_output_to_natural_units(MockExpression) == false
     @test IS.Optimization.should_write_resulting_value(MockExpression) == false
-    @test IS.Optimization.convert_result_to_natural_units(MockParameter) == false
+    @test IS.Optimization.convert_output_to_natural_units(MockParameter) == false
     @test IS.Optimization.should_write_resulting_value(MockParameter) == false
 
     # Test overridden values
-    @test IS.Optimization.convert_result_to_natural_units(MockVariable2) == true
+    @test IS.Optimization.convert_output_to_natural_units(MockVariable2) == true
     @test IS.Optimization.should_write_resulting_value(MockVariable2) == false
-    @test IS.Optimization.convert_result_to_natural_units(MockExpression2) == true
+    @test IS.Optimization.convert_output_to_natural_units(MockExpression2) == true
     @test IS.Optimization.should_write_resulting_value(MockExpression2) == false
 end
 


### PR DESCRIPTION
More uniformity: `result` -> `output` in a few places, like `get_results_base_power` and `convert_result_to_natural_units`