### PR TITLE
Use concrete type for units_info field

### DIFF
--- a/src/internal.jl
+++ b/src/internal.jl
@@ -33,7 +33,7 @@ Internal storage common to InfrastructureSystems types.
 mutable struct InfrastructureSystemsInternal <: InfrastructureSystemsType
     uuid::Base.UUID
     shared_system_references::Union{Nothing, SharedSystemReferences}
-    units_info::Union{Nothing, UnitsData}
+    units_info::Union{Nothing, SystemUnitsSettings}
     ext::Union{Nothing, Dict{String, Any}}
 end
 


### PR DESCRIPTION
## Summary
- Change `units_info` field on `InfrastructureSystemsInternal` from `Union{Nothing, UnitsData}` to `Union{Nothing, SystemUnitsSettings}`
- `UnitsData` is abstract with a single concrete subtype. Using it as the field type prevents the compiler from inferring `base_value`'s type after an `isnothing` check, causing runtime `jl_f_getfield` dispatch in every unit conversion call.

## Test plan
- [ ] IS tests pass
- [ ] PSY tests pass (no downstream changes needed — `UnitsData` abstract type is preserved for `isa` checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)