### PR TITLE
transform_single_time_series with different params

### DIFF
--- a/src/system_data.jl
+++ b/src/system_data.jl
@@ -727,8 +727,8 @@ function _check_transform_single_time_series(
         # this check will fail.
         # transform_single_time_series! cannot be called at the component level.
         # Note: has_metadata with Deterministic matches both Deterministic and
-        # DeterministicSingleTimeSeries due to abstract type dispatch. Use list_metadata
-        # and filter to check only for actual Deterministic forecasts.
+        # DeterministicSingleTimeSeries. Use list_metadata and filter to check only for
+        # actual Deterministic forecasts.
         ts_name = get_name(item.metadata)
         ts_resolution = get_resolution(item.metadata)
         ts_features = get_features(item.metadata)

--- a/src/system_data.jl
+++ b/src/system_data.jl
@@ -528,8 +528,10 @@ check_time_series_consistency(data::SystemData, ts_type) =
 Transform all instances of SingleTimeSeries to DeterministicSingleTimeSeries.
 If all SingleTimeSeries instances cannot be transformed then none will be.
 
-Any existing DeterministicSingleTimeSeries forecasts will be deleted even if the inputs are
-invalid.
+By default, any existing DeterministicSingleTimeSeries forecasts will be deleted before the
+transform (`delete_existing = true`). Set `delete_existing = false` to preserve existing
+DeterministicSingleTimeSeries; entries with matching name, resolution, features, horizon, and
+interval are skipped, allowing multiple calls with different resolutions to coexist.
 """
 function transform_single_time_series!(
     data::SystemData,
@@ -537,6 +539,7 @@ function transform_single_time_series!(
     horizon::Dates.Period,
     interval::Dates.Period;
     resolution::Union{Nothing, Dates.Period} = nothing,
+    delete_existing::Bool = true,
 )
     if is_irregular_period(horizon) || is_irregular_period(interval) ||
        (!isnothing(resolution) && is_irregular_period(resolution))
@@ -554,8 +557,42 @@ function transform_single_time_series!(
             horizon,
             interval;
             resolution = resolution,
+            delete_existing = delete_existing,
         )
     end
+end
+
+"""
+Check whether a call to `transform_single_time_series!` with the given parameters would
+complete successfully.
+
+Return `true` if the transform is valid, `false` otherwise.
+"""
+function check_transform_single_time_series(
+    data::SystemData,
+    ::Type{<:DeterministicSingleTimeSeries},
+    horizon::Dates.Period,
+    interval::Dates.Period;
+    resolution::Union{Nothing, Dates.Period} = nothing,
+)
+    if is_irregular_period(horizon) || is_irregular_period(interval) ||
+       (!isnothing(resolution) && is_irregular_period(resolution))
+        return false
+    end
+    try
+        _check_transform_single_time_series(
+            data,
+            DeterministicSingleTimeSeries,
+            horizon,
+            interval,
+            resolution;
+            skip_existing = true,
+        )
+    catch e
+        e isa ConflictingInputsError && return false
+        rethrow()
+    end
+    return true
 end
 
 function _transform_single_time_series!(
@@ -564,14 +601,18 @@ function _transform_single_time_series!(
     horizon::Dates.Period,
     interval::Dates.Period;
     resolution::Union{Nothing, Dates.Period} = nothing,
+    delete_existing::Bool = true,
 )
-    remove_time_series!(data, DeterministicSingleTimeSeries; resolution = resolution)
+    if delete_existing
+        remove_time_series!(data, DeterministicSingleTimeSeries; resolution = resolution)
+    end
     items = _check_transform_single_time_series(
         data,
         DeterministicSingleTimeSeries,
         horizon,
         interval,
-        resolution,
+        resolution;
+        skip_existing = !delete_existing,
     )
 
     if isempty(items)
@@ -625,9 +666,20 @@ function _transform_single_time_series!(
             end
         end
     catch
-        # This shouldn't be needed, but just in case there is a bug, remove all
-        # DeterministicSingleTimeSeries to keep our guarantee.
-        remove_time_series!(data, DeterministicSingleTimeSeries; resolution = resolution)
+        # Only remove the metadata entries that were added in this batch so that
+        # pre-existing DeterministicSingleTimeSeries from prior calls are preserved.
+        for (component, metadata) in zip(components, all_metadata)
+            try
+                remove_metadata!(
+                    data.time_series_manager.metadata_store,
+                    component,
+                    metadata,
+                )
+            catch ex
+                # The entry may not have been added yet; ignore.
+                ex isa ErrorException || rethrow()
+            end
+        end
         rethrow()
     end
     return
@@ -647,7 +699,8 @@ function _check_transform_single_time_series(
     ::Type{DeterministicSingleTimeSeries},
     horizon::Dates.Period,
     interval::Dates.Period,
-    resolution::Union{Nothing, Dates.Period},
+    resolution::Union{Nothing, Dates.Period};
+    skip_existing::Bool = false,
 )
     items = list_metadata_with_owner_uuid(
         data.time_series_manager.metadata_store,
@@ -656,8 +709,8 @@ function _check_transform_single_time_series(
         resolution = resolution,
     )
     system_params = get_forecast_parameters(data.time_series_manager.metadata_store)
-    components_with_params_and_metadata = Vector(undef, length(items))
-    for (i, item) in enumerate(items)
+    components_with_params_and_metadata = NamedTuple[]
+    for item in items
         params = _check_single_time_series_transformed_parameters(
             item.metadata,
             DeterministicSingleTimeSeries,
@@ -673,11 +726,14 @@ function _check_transform_single_time_series(
         # Deterministic forecasts. If other components already have Deterministic forecasts,
         # this check will fail.
         # transform_single_time_series! cannot be called at the component level.
+        # Note: has_metadata with Deterministic matches both Deterministic and
+        # DeterministicSingleTimeSeries due to abstract type dispatch. Use list_metadata
+        # and filter to check only for actual Deterministic forecasts.
         ts_name = get_name(item.metadata)
         ts_resolution = get_resolution(item.metadata)
         ts_features = get_features(item.metadata)
         ts_features_symbols = Dict{Symbol, Any}(Symbol(k) => v for (k, v) in ts_features)
-        if has_metadata(
+        existing_det = list_metadata(
             data.time_series_manager.metadata_store,
             component;
             time_series_type = Deterministic,
@@ -685,6 +741,7 @@ function _check_transform_single_time_series(
             resolution = ts_resolution,
             ts_features_symbols...,
         )
+        if any(m -> get_time_series_type(m) === Deterministic, existing_det)
             throw(
                 ConflictingInputsError(
                     "Cannot transform SingleTimeSeries to DeterministicSingleTimeSeries: " *
@@ -694,8 +751,32 @@ function _check_transform_single_time_series(
             )
         end
 
-        components_with_params_and_metadata[i] =
-            (component = component, params = params, metadata = item.metadata)
+        # If skip_existing is true, skip SingleTimeSeries entries that already have a
+        # DeterministicSingleTimeSeries with the same name, resolution, features,
+        # horizon, and interval.
+        if skip_existing
+            existing = list_metadata(
+                data.time_series_manager.metadata_store,
+                component;
+                time_series_type = DeterministicSingleTimeSeries,
+                name = ts_name,
+                resolution = ts_resolution,
+                ts_features_symbols...,
+            )
+            if any(
+                m ->
+                    get_horizon(m) == params.horizon &&
+                        get_interval(m) == params.interval,
+                existing,
+            )
+                continue
+            end
+        end
+
+        push!(
+            components_with_params_and_metadata,
+            (component = component, params = params, metadata = item.metadata),
+        )
     end
 
     return components_with_params_and_metadata

--- a/test/test_time_series.jl
+++ b/test/test_time_series.jl
@@ -1250,6 +1250,186 @@ end
     @test !IS.has_time_series(attr, IS.DeterministicSingleTimeSeries)
 end
 
+@testset "Test multiple transform_single_time_series! calls with different resolutions" begin
+    sys = IS.SystemData(; time_series_in_memory = true)
+    component = IS.TestComponent("Component1", 5)
+    IS.add_component!(sys, component)
+
+    # Add two SingleTimeSeries with different resolutions.
+    resolution1 = Dates.Minute(5)
+    dates1 = create_dates("2020-01-01T00:00:00", resolution1, "2020-01-01T23:00:00")
+    ta1 = TimeSeries.TimeArray(dates1, rand(length(dates1)), [IS.get_name(component)])
+    IS.add_time_series!(sys, component, IS.SingleTimeSeries("val1", ta1))
+
+    resolution2 = Dates.Minute(10)
+    dates2 = create_dates("2020-01-01T00:00:00", resolution2, "2020-01-01T23:00:00")
+    ta2 = TimeSeries.TimeArray(dates2, rand(length(dates2)), [IS.get_name(component)])
+    IS.add_time_series!(sys, component, IS.SingleTimeSeries("val2", ta2))
+
+    horizon = Dates.Hour(1)
+    interval = Dates.Minute(30)
+
+    # Transform only the 5-minute resolution series.
+    IS.transform_single_time_series!(
+        sys,
+        IS.DeterministicSingleTimeSeries,
+        horizon,
+        interval;
+        resolution = resolution1,
+        delete_existing = false,
+    )
+
+    # Second call for the 10-minute resolution series should succeed.
+    IS.transform_single_time_series!(
+        sys,
+        IS.DeterministicSingleTimeSeries,
+        horizon,
+        interval;
+        resolution = resolution2,
+        delete_existing = false,
+    )
+
+    # Both sets should coexist.
+    all_metadata = collect(
+        IS.get_time_series_metadata(
+            component;
+            time_series_type = IS.DeterministicSingleTimeSeries,
+        ),
+    )
+    @test length(all_metadata) == 2
+end
+
+@testset "Test transform_single_time_series! idempotent with same parameters" begin
+    sys = IS.SystemData(; time_series_in_memory = true)
+    component = IS.TestComponent("Component1", 5)
+    IS.add_component!(sys, component)
+
+    resolution = Dates.Minute(5)
+    dates = create_dates("2020-01-01T00:00:00", resolution, "2020-01-01T23:00:00")
+    data = rand(length(dates))
+    ta = TimeSeries.TimeArray(dates, data, [IS.get_name(component)])
+    ts = IS.SingleTimeSeries("val1", ta)
+    IS.add_time_series!(sys, component, ts)
+
+    horizon = Dates.Hour(1)
+    interval = Dates.Minute(30)
+    IS.transform_single_time_series!(
+        sys,
+        IS.DeterministicSingleTimeSeries,
+        horizon,
+        interval;
+        delete_existing = false,
+    )
+
+    # Same call again should be idempotent (skip existing).
+    IS.transform_single_time_series!(
+        sys,
+        IS.DeterministicSingleTimeSeries,
+        horizon,
+        interval;
+        delete_existing = false,
+    )
+
+    all_metadata = collect(
+        IS.get_time_series_metadata(
+            component;
+            time_series_type = IS.DeterministicSingleTimeSeries,
+        ),
+    )
+    @test length(all_metadata) == 1
+end
+
+@testset "Test transform_single_time_series! delete_existing removes old transforms" begin
+    sys = IS.SystemData(; time_series_in_memory = true)
+    component = IS.TestComponent("Component1", 5)
+    IS.add_component!(sys, component)
+
+    # Add two SingleTimeSeries with different resolutions.
+    resolution1 = Dates.Minute(5)
+    dates1 = create_dates("2020-01-01T00:00:00", resolution1, "2020-01-01T23:00:00")
+    ta1 = TimeSeries.TimeArray(dates1, rand(length(dates1)), [IS.get_name(component)])
+    IS.add_time_series!(sys, component, IS.SingleTimeSeries("val1", ta1))
+
+    resolution2 = Dates.Minute(10)
+    dates2 = create_dates("2020-01-01T00:00:00", resolution2, "2020-01-01T23:00:00")
+    ta2 = TimeSeries.TimeArray(dates2, rand(length(dates2)), [IS.get_name(component)])
+    IS.add_time_series!(sys, component, IS.SingleTimeSeries("val2", ta2))
+
+    horizon = Dates.Hour(1)
+    interval = Dates.Minute(30)
+
+    # Transform both resolutions without deleting.
+    IS.transform_single_time_series!(
+        sys,
+        IS.DeterministicSingleTimeSeries,
+        horizon,
+        interval;
+        delete_existing = false,
+    )
+
+    all_metadata = collect(
+        IS.get_time_series_metadata(
+            component;
+            time_series_type = IS.DeterministicSingleTimeSeries,
+        ),
+    )
+    @test length(all_metadata) == 2
+
+    # Call with delete_existing=true (the default) should remove old transforms and recreate.
+    IS.transform_single_time_series!(
+        sys,
+        IS.DeterministicSingleTimeSeries,
+        horizon,
+        interval;
+        delete_existing = true,
+    )
+
+    all_metadata = collect(
+        IS.get_time_series_metadata(
+            component;
+            time_series_type = IS.DeterministicSingleTimeSeries,
+        ),
+    )
+    @test length(all_metadata) == 2
+end
+
+@testset "Test check_transform_single_time_series" begin
+    sys = IS.SystemData(; time_series_in_memory = true)
+    component = IS.TestComponent("Component1", 5)
+    IS.add_component!(sys, component)
+
+    resolution = Dates.Minute(5)
+    dates = create_dates("2020-01-01T00:00:00", resolution, "2020-01-01T23:00:00")
+    data = rand(length(dates))
+    ta = TimeSeries.TimeArray(dates, data, [IS.get_name(component)])
+    ts = IS.SingleTimeSeries("val1", ta)
+    IS.add_time_series!(sys, component, ts)
+
+    # Valid parameters should return true.
+    @test IS.check_transform_single_time_series(
+        sys,
+        IS.DeterministicSingleTimeSeries,
+        Dates.Hour(1),
+        Dates.Minute(30),
+    )
+
+    # Horizon too large should return false.
+    @test !IS.check_transform_single_time_series(
+        sys,
+        IS.DeterministicSingleTimeSeries,
+        Dates.Hour(100),
+        Dates.Hour(1),
+    )
+
+    # Irregular period should return false.
+    @test !IS.check_transform_single_time_series(
+        sys,
+        IS.DeterministicSingleTimeSeries,
+        Dates.Month(1),
+        Dates.Hour(1),
+    )
+end
+
 @testset "Test Deterministic with a wrapped SingleTimeSeries different offsets" begin
     for in_memory in (true, false)
         sys = IS.SystemData(; time_series_in_memory = in_memory)


### PR DESCRIPTION
Previously, transform_single_time_series! deleted all existing DeterministicSingleTimeSeries on every call. Now it skips entries that already have a matching transform (same name, resolution, features, horizon, and interval), allowing multiple calls with different resolutions to coexist.

Changes:
- Add delete_existing kwarg (default false) to control deletion behavior
- Add check_transform_single_time_series to validate parameters upfront
- Fix Deterministic vs DeterministicSingleTimeSeries type check to use list_metadata + filter instead of has_metadata (abstract type dispatch matched both)
- Add horizon to time series metadata DB index
- Scope error-path cleanup to current batch only