### PR TITLE
add interval and resolution to timeseries cache

### DIFF
--- a/src/time_series_cache.jl
+++ b/src/time_series_cache.jl
@@ -147,6 +147,8 @@ struct TimeSeriesCacheKey
     component_uuid::Base.UUID
     time_series_type::Type{<:TimeSeriesData}
     name::String
+    resolution::Dates.Period
+    interval::Union{Nothing, Dates.Period}
 end
 
 struct TimeSeriesCacheCommon{T <: TimeSeriesData, U <: InfrastructureSystemsComponent}
@@ -212,7 +214,6 @@ struct ForecastCache{T <: TimeSeriesData, U <: InfrastructureSystemsComponent} <
     common::TimeSeriesCacheCommon{T, U}
     in_memory_count::Int
     horizon_count::Int
-    interval::Union{Nothing, Dates.Period}
 end
 
 """
@@ -242,8 +243,15 @@ function ForecastCache(
     cache_size_bytes = TIME_SERIES_CACHE_SIZE_BYTES,
     ignore_scaling_factors = false,
     interval::Union{Nothing, Dates.Period} = nothing,
+    resolution::Union{Nothing, Dates.Period} = nothing,
 ) where {T <: Forecast}
-    ts_metadata = get_time_series_metadata(T, component, name; interval = interval)
+    ts_metadata = get_time_series_metadata(
+        T,
+        component,
+        name;
+        resolution = resolution,
+        interval = interval,
+    )
     initial_timestamp = get_initial_timestamp(ts_metadata)
     if start_time === nothing
         start_time = initial_timestamp
@@ -259,6 +267,7 @@ function ForecastCache(
         name;
         start_time = start_time,
         len = get_horizon_count(ts_metadata),
+        resolution = resolution,
         interval = interval,
     )
     vals = get_time_series_values(
@@ -292,7 +301,6 @@ function ForecastCache(
         ),
         in_memory_count,
         horizon_count,
-        interval,
     )
 end
 
@@ -310,6 +318,7 @@ function _update!(cache::ForecastCache)
     count = _get_count(cache)
     next_time = get_next_time(cache)
     len = _get_length(cache)
+    current_ts = _get_time_series(cache)
     ts = get_time_series(
         _get_type(cache),
         _get_component(cache),
@@ -317,7 +326,8 @@ function _update!(cache::ForecastCache)
         start_time = next_time,
         len = len,
         count = count,
-        interval = cache.interval,
+        resolution = get_resolution(current_ts),
+        interval = get_interval(current_ts),
     )
     _set_length_available!(cache, len)
     _set_time_series!(cache, ts)
@@ -358,6 +368,8 @@ return a TimeSeries.TimeArray of size 1.
   - `cache_size_bytes = TIME_SERIES_CACHE_SIZE_BYTES`: maximum size of data to keep in memory
   - `ignore_scaling_factors = false`: controls whether to ignore `scaling_factor_multiplier`
     in the time series instance
+  - `resolution::Union{Nothing, Dates.Period} = nothing`: select among multiple
+    SingleTimeSeries that share `(type, name)` but differ in resolution.
 """
 function StaticTimeSeriesCache(
     ::Type{T},
@@ -366,8 +378,9 @@ function StaticTimeSeriesCache(
     cache_size_bytes = TIME_SERIES_CACHE_SIZE_BYTES,
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     ignore_scaling_factors = false,
+    resolution::Union{Nothing, Dates.Period} = nothing,
 ) where {T <: StaticTimeSeries}
-    ts_metadata = get_time_series_metadata(T, component, name)
+    ts_metadata = get_time_series_metadata(T, component, name; resolution = resolution)
     initial_timestamp = get_initial_timestamp(ts_metadata)
     if start_time === nothing
         start_time = initial_timestamp
@@ -379,7 +392,14 @@ function StaticTimeSeriesCache(
     end
 
     # Get an instance to assess data size.
-    ts = get_time_series(T, component, name; start_time = start_time, len = 1)
+    ts = get_time_series(
+        T,
+        component,
+        name;
+        start_time = start_time,
+        len = 1,
+        resolution = resolution,
+    )
     vals = get_time_series_values(component, ts; start_time = start_time, len = 1)
     row_size = _get_row_size(vals)
 
@@ -420,6 +440,7 @@ function _update!(cache::StaticTimeSeriesCache)
         _get_name(cache);
         start_time = next_time,
         len = len,
+        resolution = get_resolution(_get_time_series(cache)),
     )
     _set_length_available!(cache, len)
     _set_time_series!(cache, ts)
@@ -460,6 +481,7 @@ function make_time_series_cache(
     initial_time,
     len::Int;
     ignore_scaling_factors = true,
+    resolution::Union{Nothing, Dates.Period} = nothing,
 ) where {T <: StaticTimeSeries}
     return StaticTimeSeriesCache(
         T,
@@ -467,6 +489,7 @@ function make_time_series_cache(
         name;
         start_time = initial_time,
         ignore_scaling_factors = ignore_scaling_factors,
+        resolution = resolution,
     )
 end
 
@@ -478,6 +501,7 @@ function make_time_series_cache(
     horizon_count::Int;
     ignore_scaling_factors = true,
     interval::Union{Nothing, Dates.Period} = nothing,
+    resolution::Union{Nothing, Dates.Period} = nothing,
 ) where {T <: AbstractDeterministic}
     return ForecastCache(
         T,
@@ -487,6 +511,7 @@ function make_time_series_cache(
         horizon_count = horizon_count,
         ignore_scaling_factors = ignore_scaling_factors,
         interval = interval,
+        resolution = resolution,
     )
 end
 
@@ -498,6 +523,7 @@ function make_time_series_cache(
     horizon_count::Int;
     ignore_scaling_factors = true,
     interval::Union{Nothing, Dates.Period} = nothing,
+    resolution::Union{Nothing, Dates.Period} = nothing,
 )
     return ForecastCache(
         Probabilistic,
@@ -507,5 +533,6 @@ function make_time_series_cache(
         horizon_count = horizon_count,
         ignore_scaling_factors = ignore_scaling_factors,
         interval = interval,
+        resolution = resolution,
     )
 end

--- a/src/time_series_cache.jl
+++ b/src/time_series_cache.jl
@@ -233,6 +233,10 @@ will return a TimeSeries.TimeArray covering one forecast window of length `horiz
   - `cache_size_bytes = TIME_SERIES_CACHE_SIZE_BYTES`: maximum size of data to keep in memory
   - `ignore_scaling_factors = false`: controls whether to ignore `scaling_factor_multiplier`
     in the time series instance
+  - `interval::Union{Nothing, Dates.Period} = nothing`: select among multiple forecasts
+    that share `(type, name)` but differ in interval.
+  - `resolution::Union{Nothing, Dates.Period} = nothing`: select among multiple forecasts
+    that share `(type, name)` but differ in resolution.
 """
 function ForecastCache(
     ::Type{T},

--- a/src/time_series_interface.jl
+++ b/src/time_series_interface.jl
@@ -203,9 +203,16 @@ function get_time_series_uuid(
     ::Type{T},
     component::InfrastructureSystemsComponent,
     name::AbstractString;
+    resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
 ) where {T <: TimeSeriesData}
-    metadata = get_time_series_metadata(T, component, name; interval = interval)
+    metadata = get_time_series_metadata(
+        T,
+        component,
+        name;
+        resolution = resolution,
+        interval = interval,
+    )
     return get_time_series_uuid(metadata)
 end
 

--- a/test/test_time_series.jl
+++ b/test/test_time_series.jl
@@ -3325,7 +3325,35 @@ end
     ts = IS.SingleTimeSeries(; data = data, name = ts_name)
     uuid = IS.get_uuid(ts)
     IS.add_time_series!(sys, component, ts)
-    ts2 = IS.get_time_series_uuid(IS.SingleTimeSeries, component, ts_name)
+    @test IS.get_time_series_uuid(IS.SingleTimeSeries, component, ts_name) == uuid
+end
+
+@testset "Test get_time_series_uuid with multiple resolutions" begin
+    params = setup_for_multi_resolution_tests()
+    component = params.component
+    sts_name = params.sts_name
+    resolution1 = params.resolution1
+    resolution2 = params.resolution2
+    uuid1 = IS.get_uuid(params.sts1)
+    uuid2 = IS.get_uuid(params.sts2)
+
+    @test IS.get_time_series_uuid(
+        IS.SingleTimeSeries,
+        component,
+        sts_name;
+        resolution = resolution1,
+    ) == uuid1
+    @test IS.get_time_series_uuid(
+        IS.SingleTimeSeries,
+        component,
+        sts_name;
+        resolution = resolution2,
+    ) == uuid2
+    @test_throws ArgumentError IS.get_time_series_uuid(
+        IS.SingleTimeSeries,
+        component,
+        sts_name,
+    )
 end
 
 @testset "Test serialization of time series keys" begin
@@ -4893,6 +4921,128 @@ end
         initial_time,
         horizon_count;
         interval = interval1,
+    )
+    ta3 = IS.get_time_series_array!(cache3, initial_time)
+    @test TimeSeries.values(ta3) == expected_vals1
+end
+
+@testset "Test ForecastCache with multiple resolutions" begin
+    params = setup_for_multi_resolution_tests()
+    component = params.component
+    f_name = params.f_name
+    initial_time = params.initial_time
+    resolution1 = params.resolution1
+    resolution2 = params.resolution2
+    f1 = params.forecast1
+    f2 = params.forecast2
+
+    horizon_count1 = length(first(values(IS.get_data(f1))))
+    horizon_count2 = length(first(values(IS.get_data(f2))))
+
+    # Cache with resolution1 returns resolution1 data
+    cache1 = IS.ForecastCache(
+        IS.Deterministic,
+        component,
+        f_name;
+        start_time = initial_time,
+        horizon_count = horizon_count1,
+        resolution = resolution1,
+    )
+    ta1 = IS.get_time_series_array!(cache1, initial_time)
+    expected_vals1 = IS.get_data(f1)[initial_time]
+    @test TimeSeries.values(ta1) == expected_vals1
+
+    # Cache with resolution2 returns resolution2 data
+    cache2 = IS.ForecastCache(
+        IS.Deterministic,
+        component,
+        f_name;
+        start_time = initial_time,
+        horizon_count = horizon_count2,
+        resolution = resolution2,
+    )
+    ta2 = IS.get_time_series_array!(cache2, initial_time)
+    expected_vals2 = IS.get_data(f2)[initial_time]
+    @test TimeSeries.values(ta2) == expected_vals2
+
+    # Values from different resolutions are different
+    @test expected_vals1 != expected_vals2
+
+    # Cache without resolution throws on ambiguous data
+    @test_throws ArgumentError IS.ForecastCache(
+        IS.Deterministic,
+        component,
+        f_name;
+        start_time = initial_time,
+        horizon_count = horizon_count1,
+    )
+
+    # make_time_series_cache with resolution works
+    cache3 = IS.make_time_series_cache(
+        IS.Deterministic,
+        component,
+        f_name,
+        initial_time,
+        horizon_count1;
+        resolution = resolution1,
+    )
+    ta3 = IS.get_time_series_array!(cache3, initial_time)
+    @test TimeSeries.values(ta3) == expected_vals1
+end
+
+@testset "Test StaticTimeSeriesCache with multiple resolutions" begin
+    params = setup_for_multi_resolution_tests()
+    component = params.component
+    sts_name = params.sts_name
+    initial_time = params.initial_time
+    resolution1 = params.resolution1
+    resolution2 = params.resolution2
+    sts1 = params.sts1
+    sts2 = params.sts2
+
+    # Cache with resolution1 returns resolution1 data
+    cache1 = IS.StaticTimeSeriesCache(
+        IS.SingleTimeSeries,
+        component,
+        sts_name;
+        start_time = initial_time,
+        resolution = resolution1,
+    )
+    ta1 = IS.get_time_series_array!(cache1, initial_time)
+    expected_vals1 = TimeSeries.values(IS.get_data(sts1))[1:1]
+    @test TimeSeries.values(ta1) == expected_vals1
+
+    # Cache with resolution2 returns resolution2 data
+    cache2 = IS.StaticTimeSeriesCache(
+        IS.SingleTimeSeries,
+        component,
+        sts_name;
+        start_time = initial_time,
+        resolution = resolution2,
+    )
+    ta2 = IS.get_time_series_array!(cache2, initial_time)
+    expected_vals2 = TimeSeries.values(IS.get_data(sts2))[1:1]
+    @test TimeSeries.values(ta2) == expected_vals2
+
+    # Values from different resolutions are different
+    @test expected_vals1 != expected_vals2
+
+    # Cache without resolution throws on ambiguous data
+    @test_throws ArgumentError IS.StaticTimeSeriesCache(
+        IS.SingleTimeSeries,
+        component,
+        sts_name;
+        start_time = initial_time,
+    )
+
+    # make_time_series_cache with resolution works
+    cache3 = IS.make_time_series_cache(
+        IS.SingleTimeSeries,
+        component,
+        sts_name,
+        initial_time,
+        1;
+        resolution = resolution1,
     )
     ta3 = IS.get_time_series_array!(cache3, initial_time)
     @test TimeSeries.values(ta3) == expected_vals1


### PR DESCRIPTION
In order to use a single system in many models in PSI, the TimeSeriesCache keys needs more information to get the time series correctly 