### PR TITLE
is_time_series_backed on `FuelCurve`

### DIFF
--- a/src/production_variable_cost_curve.jl
+++ b/src/production_variable_cost_curve.jl
@@ -177,9 +177,10 @@ get_fuel_cost(cost::FuelCurve) = cost.fuel_cost
 get_startup_fuel_offtake(cost::FuelCurve) = cost.startup_fuel_offtake
 
 is_time_series_backed(::TimeSeriesKey) = true
-is_time_series_backed(::Nothing) = false
+is_time_series_backed(::Union{Nothing, Float64}) = false
 "Check if the cost curve is backed by time series data"
-is_time_series_backed(cost::CostCurve) = is_time_series_backed(get_value_curve(cost))
+is_time_series_backed(cost::ProductionVariableCostCurve) =
+    is_time_series_backed(get_value_curve(cost))
 # FuelCurve's fuel_cost is Union{Float64, TimeSeriesKey} — check both the value curve and fuel_cost.
 is_time_series_backed(cost::FuelCurve) =
     is_time_series_backed(get_value_curve(cost)) ||

--- a/src/production_variable_cost_curve.jl
+++ b/src/production_variable_cost_curve.jl
@@ -40,9 +40,6 @@ function is_concave(curve::ValueCurve{T}) where {T <: TimeSeriesFunctionData}
     )
 end
 is_concave(cost::ProductionVariableCostCurve) = is_concave(get_value_curve(cost))
-"Check if the cost curve is backed by time series data"
-is_time_series_backed(cost::ProductionVariableCostCurve) =
-    is_time_series_backed(get_value_curve(cost))
 "Get the `TimeSeriesKey` from the underlying `ValueCurve` of a time-series-backed `ProductionVariableCostCurve`."
 get_time_series_key(
     cost::ProductionVariableCostCurve{<:ValueCurve{<:TimeSeriesFunctionData}},
@@ -178,6 +175,15 @@ Base.zero(::Union{FuelCurve, Type{FuelCurve}}) = FuelCurve(zero(ValueCurve), 0.0
 get_fuel_cost(cost::FuelCurve) = cost.fuel_cost
 "Get the function for the fuel consumption at startup"
 get_startup_fuel_offtake(cost::FuelCurve) = cost.startup_fuel_offtake
+
+is_time_series_backed(::TimeSeriesKey) = true
+is_time_series_backed(::Nothing) = false
+"Check if the cost curve is backed by time series data"
+is_time_series_backed(cost::CostCurve) = is_time_series_backed(get_value_curve(cost))
+# FuelCurve's fuel_cost is Union{Float64, TimeSeriesKey} — check both the value curve and fuel_cost.
+is_time_series_backed(cost::FuelCurve) =
+    is_time_series_backed(get_value_curve(cost)) ||
+    is_time_series_backed(get_fuel_cost(cost))
 
 Base.show(io::IO, m::MIME"text/plain", curve::ProductionVariableCostCurve) =
     (get(io, :compact, false)::Bool ? _show_compact : _show_expanded)(io, m, curve)

--- a/test/test_cost_functions.jl
+++ b/test/test_cost_functions.jl
@@ -338,6 +338,36 @@ end
           IS.LinearCurve(10.0, 7.0)
 end
 
+@testset "is_time_series_backed for CostCurve and FuelCurve" begin
+    forecast_key = IS.ForecastKey(;
+        time_series_type = IS.Deterministic,
+        name = "fuel_price",
+        initial_timestamp = Dates.DateTime("2020-01-01"),
+        resolution = Dates.Hour(1),
+        horizon = Dates.Hour(24),
+        interval = Dates.Hour(24),
+        count = 1,
+        features = Dict{String, Any}(),
+    )
+
+    # Scalar dispatches
+    @test IS.is_time_series_backed(forecast_key) == true
+    @test IS.is_time_series_backed(nothing) == false
+
+    static_vc = IS.InputOutputCurve(IS.QuadraticFunctionData(1, 2, 3))
+    ts_vc = IS.InputOutputCurve(IS.TimeSeriesQuadraticFunctionData(forecast_key))
+
+    # CostCurve: only time-series-backed when its value curve is
+    @test IS.is_time_series_backed(IS.CostCurve(static_vc)) == false
+    @test IS.is_time_series_backed(IS.CostCurve(ts_vc)) == true
+
+    # FuelCurve 2x2: fuel_cost ∈ {Float64, TimeSeriesKey} × value_curve ∈ {static, time-varying}
+    @test IS.is_time_series_backed(IS.FuelCurve(static_vc, 4.0)) == false
+    @test IS.is_time_series_backed(IS.FuelCurve(ts_vc, 4.0)) == true
+    @test IS.is_time_series_backed(IS.FuelCurve(static_vc, forecast_key)) == true
+    @test IS.is_time_series_backed(IS.FuelCurve(ts_vc, forecast_key)) == true
+end
+
 @testset "Test prohibited FunctionData types" begin
     # Incremental and Average Rate curves only support
     # linear and piecewise step function data.


### PR DESCRIPTION
There are some test failures, but they're unrelated: it's module prefix vs no module prefix discrepancies in the `sprint` and `repr` tests