### PR TITLE
Adopt Rust-core time series APIs; remove the time-series UUID

### DIFF
--- a/docs/src/dev_guide/associations_database.md
+++ b/docs/src/dev_guide/associations_database.md
@@ -2,146 +2,48 @@
 
 !!! note "For Maintainers and Contributors"
     
-    This page documents the internal database schemas used by InfrastructureSystems.jl to manage associations between components and their time series data and supplemental attributes. This information is intended for maintainers and contributors working on the codebase. **End users should not need to interact with these databases directly.**
+    This page documents the internal databases used by InfrastructureSystems.jl to manage associations between components and their time series data and supplemental attributes. This information is intended for maintainers and contributors working on the codebase. **End users should not need to interact with these databases directly.**
 
 ## Overview
 
-InfrastructureSystems.jl uses SQLite databases to efficiently track associations between:
+InfrastructureSystems.jl tracks two kinds of associations, each with its own storage:
 
-  - **Components** and **Time Series data**
-  - **Components** and **Supplemental Attributes**
+ 1. **Components/supplemental attributes ↔ time series data** — managed by the
+    `time-series-store` Rust backend (wrapped by `TimeSeriesStore.jl`). Both the numerical
+    arrays and the association catalog live there; IS.jl does not maintain its own time series
+    metadata database. See [Time Series Data](@ref) for the on-disk artifact and catalog model.
+ 2. **Components ↔ supplemental attributes** — managed by IS.jl in an in-memory SQLite
+    database (`SupplementalAttributeAssociations`).
 
-These associations are managed under the hood to enable:
+These associations enable fast lookups, efficient filtering, proper lifecycle management
+(add/remove/update), and serialization/deserialization.
 
-  - Fast lookups of time series and attributes attached to components
-  - Efficient querying and filtering
-  - Proper lifecycle management (adding, removing, updating references)
-  - Serialization and deserialization support
+## Time Series Associations (Rust backend)
 
-The package maintains two separate databases:
+Time series associations are stored by the `time-series-store` backend, not by an
+IS.jl-managed SQLite database. The on-disk artifact is a NetCDF file (`<path>.nc`) for the
+arrays plus a sibling SQLite catalog (`<path>.sqlite`) for the associations; the two files are
+one logical unit and must be moved, copied, and deleted together. Each association is
+identified by the owner (`owner_id` + `owner_category`), `name`, `resolution`, `features`, and
+the concrete `time_series_type`, together with the array's SHA-256 content hash (which provides
+automatic de-duplication).
 
- 1. **Time Series Metadata Store** - tracks time series associations
- 2. **Supplemental Attribute Associations** - tracks supplemental attribute associations
+For the on-disk layout, the catalog columns and indexes, and the `DATA_FORMAT_VERSION`
+compatibility contract, see [Time Series Data](@ref) and the `time-series-store` repository's
+file-format reference. The IS.jl glue lives in
+[`src/rust_time_series_store.jl`](https://github.com/Sienna-Platform/InfrastructureSystems.jl/blob/main/src/rust_time_series_store.jl).
 
-## Design Rationale
-
-### Why Separate Databases?
-
-Time series metadata and supplemental attribute associations are stored in independent SQLite databases rather than different tables in the same database. This design decision is driven by serialization requirements:
-
-**Background:**
-
-  - Time series metadata is always persisted as a SQLite file during serialization
-  - The SQLite file is written as an HDF5 dataset in the time series data file
-  - Serialization produces: `system.json`, `system_metadata.json`, and `system_time_series.h5`
-  - If there is no time series in the system, only `system.json` and `system_metadata.json` are produced
-
-**The Problem:**
-If supplemental attribute associations were in the same database as time series metadata, and the system had supplemental attributes but no time series, serialization would produce an extra file. The team required that supplemental attribute associations be written to the system JSON file when there is no time series data.
-
-**The Solution:**
-Keeping them as separate databases simplifies the code by avoiding the complexity of temporarily sharing a database across serialization and deepcopy operations. The supplemental attribute database is always ephemeral (in-memory only), while the time series metadata can be persisted.
-
-## Time Series Metadata Store
-
-The `TimeSeriesMetadataStore` manages associations between time series data and components/supplemental attributes. It uses an in-memory SQLite database for fast access.
-
-### Database Tables
-
-#### 1. `time_series_associations` Table
-
-This is the primary table that stores the associations between time series data and owners (components or supplemental attributes).
-
-**Schema:**
-
-| Column Name                 | Type    | Description                                                                                 |
-|:--------------------------- |:------- |:------------------------------------------------------------------------------------------- |
-| `id`                        | INTEGER | Primary key, auto-incremented                                                               |
-| `time_series_uuid`          | TEXT    | UUID of the time series data array                                                          |
-| `time_series_type`          | TEXT    | Type name of the time series (e.g., "SingleTimeSeries", "Deterministic")                    |
-| `initial_timestamp`         | TEXT    | ISO 8601 formatted initial timestamp                                                        |
-| `resolution`                | TEXT    | Resolution encoded as [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations) |
-| `horizon`                   | TEXT    | ISO 8601 formatted forecast horizon (NULL for static time series)                           |
-| `interval`                  | TEXT    | ISO 8601 formatted forecast interval (NULL for static time series)                          |
-| `window_count`              | INTEGER | Number of forecast windows (NULL for static time series)                                    |
-| `length`                    | INTEGER | Length of static time series (NULL for forecasts)                                           |
-| `name`                      | TEXT    | User-defined name for the time series                                                       |
-| `owner_uuid`                | TEXT    | UUID of the component or supplemental attribute that owns this                              |
-| `owner_type`                | TEXT    | Type name of the owner                                                                      |
-| `owner_category`            | TEXT    | Either "Component" or "SupplementalAttribute"                                               |
-| `features`                  | TEXT    | JSON string of feature key-value pairs for filtering                                        |
-| `scaling_factor_multiplier` | JSON    | Optional function for scaling (NULL if not used)                                            |
-| `metadata_uuid`             | TEXT    | UUID of the metadata object                                                                 |
-| `units`                     | TEXT    | Optional units specification (NULL if not used)                                             |
-
-**Indexes:**
-
-  - `by_c_n_tst_features`: Composite index on `(owner_uuid, time_series_type, name, resolution, features)` - optimized for lookups by component with specific time series parameters
-  - `by_ts_uuid`: Index on `(time_series_uuid)` - optimized for finding all owners of a specific time series
-
-**Design Notes:**
-
-  - The table supports both static time series and forecasts. Forecast-specific columns (`horizon`, `interval`, `window_count`) are NULL for static time series.
-  - The `features` column stores a JSON string of key-value pairs that can be used for flexible filtering and querying.
-  - All `Dates.Period` values are stored as ISO 8601 strings for portability.
-  - The `metadata_uuid` allows multiple associations to reference the same metadata object (stored in memory).
-
-#### 2. `key_value_store` Table
-
-Stores metadata about the database itself.
-
-**Schema:**
-
-| Column Name | Type | Description |
-|:----------- |:---- |:----------- |
-| `key`       | TEXT | Primary key |
-| `value`     | JSON | JSON value  |
-
-**Current Keys:**
-
-  - `version`: Stores the time series metadata format version (currently "1.0.0")
-
-### Common Queries
-
-The following types of queries are optimized by the indexes:
-
- 1. **Find all time series for a component:**
+!!! note "Component and time series identifiers"
     
-    ```sql
-    SELECT * FROM time_series_associations WHERE owner_uuid = ?
-    ```
-
- 2. **Find specific time series by name and type:**
-    
-    ```sql
-    SELECT * FROM time_series_associations 
-    WHERE owner_uuid = ? AND name = ? AND time_series_type = ?
-    ```
- 3. **Find time series with specific features:**
-    
-    ```sql
-    SELECT * FROM time_series_associations 
-    WHERE owner_uuid = ? AND features LIKE ?
-    ```
- 4. **Find all owners of a time series:**
-    
-    ```sql
-    SELECT DISTINCT owner_uuid FROM time_series_associations 
-    WHERE time_series_uuid = ?
-    ```
-
-### Migrations
-
-The database schema has evolved over time. Migration code handles upgrading from older formats:
-
-  - **v2.3 Migration**: Converted from a single metadata table with JSON columns to the current two-table structure
-  - **v2.4 Migration**: Converted period storage from integer milliseconds to ISO 8601 strings
-
-Migration functions (`_migrate_from_v2_3`, `_migrate_from_v2_4`) are maintained in `time_series_metadata_store.jl` for backward compatibility.
+    Components and supplemental attributes are identified by integer IDs, and time series data
+    is identified by its array content hash. There is no `time_series_uuid` — to address a
+    specific time series use its [`TimeSeriesKey`](@ref) (see [Time Series Data](@ref)).
 
 ## Supplemental Attribute Associations
 
-The `SupplementalAttributeAssociations` manages associations between supplemental attributes and components. It uses an in-memory SQLite database that is always ephemeral.
+`SupplementalAttributeAssociations` manages associations between supplemental attributes and
+components in an in-memory SQLite database that is always ephemeral (never persisted as a
+database file; associations are serialized to the system JSON instead).
 
 ### Database Table
 
@@ -149,181 +51,78 @@ The `SupplementalAttributeAssociations` manages associations between supplementa
 
 **Schema:**
 
-| Column Name      | Type | Description                             |
-|:---------------- |:---- |:--------------------------------------- |
-| `attribute_uuid` | TEXT | UUID of the supplemental attribute      |
-| `attribute_type` | TEXT | Type name of the supplemental attribute |
-| `component_uuid` | TEXT | UUID of the component                   |
-| `component_type` | TEXT | Type name of the component              |
+| Column Name      | Type    | Description                             |
+|:---------------- |:------- |:--------------------------------------- |
+| `attribute_id`   | INTEGER | ID of the supplemental attribute        |
+| `attribute_type` | TEXT    | Type name of the supplemental attribute |
+| `component_id`   | INTEGER | ID of the component                     |
+| `component_type` | TEXT    | Type name of the component              |
 
 **Indexes:**
 
-  - `by_attribute`: Composite index on `(attribute_uuid, component_uuid, component_type)` - optimized for finding components associated with an attribute
-  - `by_component`: Composite index on `(component_uuid, attribute_uuid, attribute_type)` - optimized for finding attributes associated with a component
+  - `by_attribute`: Composite index on `(attribute_id, component_id, component_type)` — optimized for finding components associated with an attribute.
+  - `by_component`: Composite index on `(component_id, attribute_id, attribute_type)` — optimized for finding attributes associated with a component.
 
 **Design Notes:**
 
-  - The schema is simpler than the time series associations because supplemental attributes have less metadata
-  - Both attribute and component information is stored to enable bidirectional lookups
-  - The indexes support fast queries in both directions (attribute → components and component → attributes)
+  - Both attribute and component information is stored to enable bidirectional lookups.
+  - The indexes support fast queries in both directions (attribute → components and component → attributes).
 
 ### Common Queries
 
  1. **Find all attributes for a component:**
     
     ```sql
-    SELECT DISTINCT attribute_uuid FROM supplemental_attributes 
-    WHERE component_uuid = ?
+    SELECT DISTINCT attribute_id FROM supplemental_attributes
+    WHERE component_id = ?
     ```
 
  2. **Find attributes of a specific type for a component:**
     
     ```sql
-    SELECT DISTINCT attribute_uuid FROM supplemental_attributes 
-    WHERE component_uuid = ? AND attribute_type = ?
+    SELECT DISTINCT attribute_id FROM supplemental_attributes
+    WHERE component_id = ? AND attribute_type = ?
     ```
  3. **Find all components with an attribute:**
     
     ```sql
-    SELECT DISTINCT component_uuid FROM supplemental_attributes 
-    WHERE attribute_uuid = ?
+    SELECT DISTINCT component_id FROM supplemental_attributes
+    WHERE attribute_id = ?
     ```
  4. **Check if an association exists:**
     
     ```sql
-    SELECT attribute_uuid FROM supplemental_attributes 
-    WHERE attribute_uuid = ? AND component_uuid = ? 
+    SELECT attribute_id FROM supplemental_attributes
+    WHERE attribute_id = ? AND component_id = ?
     LIMIT 1
     ```
 
-## Performance Considerations
-
-### Statement Caching
-
-Both database implementations cache compiled SQL statements to avoid the overhead of re-parsing queries. This saves approximately 3-4 microseconds per query.
-
-  - `TimeSeriesMetadataStore` maintains a `cached_statements` dictionary
-  - `SupplementalAttributeAssociations` maintains a `cached_statements` dictionary
-  - Frequently-used queries benefit most from caching
-
-### Index Strategy
-
-**Time Series Metadata:**
-
- 1. Optimize for user queries by component/attribute UUID with name, type, and resolution
- 2. Optimize for deduplication checks during `add_time_series!`
- 3. Optimize for metadata retrieval by time series UUID
-
-**Supplemental Attributes:**
-
- 1. Optimize for bidirectional lookups (attribute ↔ component)
- 2. Support filtering by type in both directions
-
-### Database Location
-
-  - Both databases are in-memory (`SQLite.DB()`) for performance
-  - The time series metadata database can be backed up to disk for serialization
-  - The supplemental attribute database is never persisted (associations are stored in JSON during serialization)
-
 ## Serialization Behavior
 
-### Time Series Metadata
+### Time Series
 
-During serialization:
-
- 1. The in-memory database is backed up to a temporary file
- 2. Indexes are dropped from the backup (to reduce file size)
- 3. The database file is written as an HDF5 dataset in `system_time_series.h5`
-
-During deserialization:
-
- 1. The SQLite database is extracted from the HDF5 file
- 2. It's loaded into an in-memory database
- 3. Indexes are recreated for performance
- 4. Metadata objects are reconstructed and cached in memory
+Time series data and its association catalog are persisted by the `time-series-store` backend
+as the `<path>.nc` / `<path>.sqlite` pair described above. See [Time Series Data](@ref).
 
 ### Supplemental Attribute Associations
 
-During serialization:
-
- 1. All associations are extracted as records (tuples of UUIDs and types)
- 2. Records are written to the JSON file
-
-During deserialization:
-
- 1. Records are read from the JSON file
- 2. A new in-memory database is created
- 3. Records are bulk-inserted using `executemany` for efficiency
- 4. Indexes are created
+The supplemental attribute database is in-memory and ephemeral. During serialization the
+associations are extracted as records and written to the system JSON file; during
+deserialization the records are read back and bulk-inserted into a fresh in-memory database,
+then indexed.
 
 ## Implementation Files
 
-  - **Time Series Metadata Store**: [`src/time_series_metadata_store.jl`](https://github.com/Sienna-Platform/InfrastructureSystems.jl/blob/main/src/time_series_metadata_store.jl)
+  - **Time Series (Rust backend) glue**: [`src/rust_time_series_store.jl`](https://github.com/Sienna-Platform/InfrastructureSystems.jl/blob/main/src/rust_time_series_store.jl)
   - **Supplemental Attribute Associations**: [`src/supplemental_attribute_associations.jl`](https://github.com/Sienna-Platform/InfrastructureSystems.jl/blob/main/src/supplemental_attribute_associations.jl)
   - **SQLite Utilities**: [`src/utils/sqlite.jl`](https://github.com/Sienna-Platform/InfrastructureSystems.jl/blob/main/src/utils/sqlite.jl)
 
-## Debugging and Inspection
-
-### Querying the Databases
-
-Both stores provide a `sql()` function for running custom queries:
-
-```julia
-# Query time series associations
-df = InfrastructureSystems.sql(
-    store,
-    "SELECT * FROM time_series_associations WHERE owner_type = 'Generator'",
-)
-
-# Query supplemental attribute associations  
-df = InfrastructureSystems.sql(
-    associations,
-    "SELECT * FROM supplemental_attributes WHERE component_type = 'Bus'",
-)
-```
-
-### Viewing as DataFrames
-
-```julia
-# Time series associations as DataFrame
-df = InfrastructureSystems.to_dataframe(store)
-
-# Supplemental attributes as records
-records = InfrastructureSystems.to_records(associations)
-```
-
-### Summary Functions
-
-Both stores provide summary functions:
-
-```julia
-# Time series summaries
-counts = InfrastructureSystems.get_time_series_counts(store)
-summary_table = InfrastructureSystems.get_forecast_summary_table(store)
-
-# Supplemental attribute summaries
-summary_table = InfrastructureSystems.get_attribute_summary_table(associations)
-num_attrs = InfrastructureSystems.get_num_attributes(associations)
-```
-
 ## Best Practices for Developers
 
- 1. **Use Transactions**: When making multiple related changes, wrap them in a SQLite transaction for atomicity and performance
-
- 2. **Leverage Indexes**: Design queries to take advantage of the existing indexes. Check query plans if performance is a concern.
- 3. **Cache Statements**: For frequently-executed queries, use the cached statement methods (`_execute_cached`) rather than creating new statements each time
- 4. **Validate Migrations**: When modifying the schema, ensure migration code is added and tested with data from older versions
- 5. **Test with Large Datasets**: Performance characteristics can change significantly with large numbers of associations. Test with realistic data sizes.
- 6. **Handle Edge Cases**: Consider abstract types, subtypes, and empty result sets in query logic
- 7. **Maintain Consistency**: When adding/removing associations, ensure both the database and any in-memory caches (like `metadata_uuids` in TimeSeriesMetadataStore) are updated together
-
-## Future Considerations
-
-Potential areas for enhancement:
-
-  - **Query Optimization**: Profile and optimize hot paths, especially for large systems
-  - **Schema Versioning**: Maintain a clear versioning strategy as the schema evolves
-  - **Partial Indexes**: Consider partial indexes for common filtered queries
-  - **Bulk Operations**: Optimize bulk insert/delete operations for large datasets
-  - **Foreign Keys**: Currently not used; could add foreign key constraints for data integrity if needed
-  - **Full-Text Search**: For advanced filtering on text fields like `name` or `features`
+ 1. **Use transactions** when making multiple related changes, for atomicity and performance.
+ 2. **Leverage indexes**: design queries to take advantage of the existing indexes.
+ 3. **Cache statements** for frequently-executed queries rather than re-creating them.
+ 4. **Maintain consistency**: when adding or removing associations, ensure the database and any
+    in-memory caches are updated together.
+ 5. **Test with large datasets**: performance characteristics can change significantly with
+    large numbers of associations.

--- a/docs/src/dev_guide/time_series.md
+++ b/docs/src/dev_guide/time_series.md
@@ -4,32 +4,42 @@
 series data. This document contains content for developers of new time series data. For the
 usage please refer to the documentation in [PowerSystems.jl](https://sienna-platform.github.io/PowerSystems.jl/stable).
 
-`InfrastructureSystems.jl` provides a mechanism to store time series data for
-components. Here are reasons to consider using it:
+Time series storage is backed by the `time-series-store` Rust library (wrapped by the
+`TimeSeriesStore.jl` binding). Reasons to consider using it:
 
-  - Time series data, by default, is stored independently of components in HDF5 files. Components store references to that data.
-  - System memory is not depleted by loading all time series data at once. Only data that you need is loaded.
-  - Multiple components can share the same time series data by sharing references instead of
-    making expensive copies.
+  - Numerical arrays are stored independently of components in a NetCDF file with a SQLite
+    catalog; components store associations to that data rather than copies.
+  - System memory is not depleted by loading all time series data at once. Only data that you
+    need is loaded.
+  - Storage is **content-addressed**: identical arrays are de-duplicated automatically by their
+    SHA-256 hash, so multiple components or supplemental attributes that share the same data
+    cost a single array on disk.
   - Supports serialization and deserialization.
   - Supports parsing raw data files of several formats as well as data stored in
     `TimeSeries.TimeArray` and `DataFrames.DataFrame` objects.
 
-> **Your package must reimplement a deepcopy method if you use HDF5 storage for TimeSeriesData.**
+## On-disk artifact
 
-If you store an instance of [`InfrastructureSystems.SystemData`](@ref) within your
-system and then a user calls `deepcopy` on a system, the .h5 file will not be copied.
-The new and old instances will have references to the same file. You will need to
-reimplement `deepcopy` to handle this. One solution is to serialize and then
-deserialize the system.
+A persisted store is **two files that form one logical artifact** and must be moved, copied,
+and deleted together:
+
+  - `<path>.nc` — a NetCDF4 file holding the numerical arrays.
+  - `<path>.sqlite` — a SQLite catalog of time series *associations* (metadata).
+
+> **`deepcopy` does not duplicate the on-disk `.nc`/`.sqlite` files.** A `deepcopy` of a
+> system yields a new object that still references the same files on disk. To obtain an
+> independent copy, serialize and then deserialize the system.
 
 *Notes*:
 
-  - Time series data can optionally be stored fully in memory. Refer to the [`InfrastructureSystems.SystemData`](@ref) documentation.
-  - `InfrastructureSystems.jl` creates HDF5 files on the tmp filesystem by default, using the location obtained from `tempdir()`. This can be changed if the time series data is larger than the amount of tmp space available. Refer to the [`InfrastructureSystems.SystemData`](@ref) link above.
-  - By default, the call to `add_time_series!` will open the .h5 file, write the data to the file,
-    and close the file. Opening and closing the file has overhead. If you will add thousands of time
-    series arrays, consider using `open_time_series_store!` to add all the arrays with one file handle.
+  - Time series data can optionally be stored fully in memory. Refer to the
+    [`InfrastructureSystems.SystemData`](@ref) documentation (`time_series_in_memory`).
+  - On-disk artifacts are created on the tmp filesystem by default, using the location obtained
+    from `tempdir()`. This can be changed via `time_series_directory` if the data is larger than
+    the available tmp space. Refer to the [`InfrastructureSystems.SystemData`](@ref) link above.
+  - By default, the call to `add_time_series!` writes and flushes per call, which has overhead.
+    If you will add thousands of time series arrays, batch them with `open_time_series_store!`
+    (or `bulk_add_time_series!`) so a single handle is reused.
 
 ## Instructions
 
@@ -38,63 +48,54 @@ deserialize the system.
 
 ## Data Format
 
-Time series arrays are stored in an
-[HDF5](https://support.hdfgroup.org/HDF5/whatishdf5.html) file according the
-format described here.
+Numerical arrays live in the NetCDF file, keyed by the SHA-256 hash of their contents
+(content addressing, which yields automatic de-duplication). The SQLite catalog records one
+row per **association** between an owner (component or supplemental attribute) and a stored
+array, identified by:
 
-The root path `/time_series` defines these HDF5 attributes to control deserialization:
+  - `owner_id` and `owner_category` (component or supplemental attribute)
+  - `name`
+  - `resolution`
+  - `features` (user-defined tags)
+  - `time_series_type` (`SingleTimeSeries`, `Deterministic`, `Probabilistic`, `Scenarios`, or
+    `DeterministicSingleTimeSeries`)
 
-  - `data_format_version`: Designates the InfrastructureSystems format for the file.
-  - `compression_enabled`: Specifies whether compression is enabled and will be used for new time series.
-  - `compression_type`: Specifies the type of compression being used.
-  - `compression_level`: Specifies the level of compression being used.
-  - `compression_shuffle`: Specifies whether the shuffle filter is being used.
+together with the forecast window parameters (`initial_timestamp`, `horizon`, `interval`,
+`count`) and the array's content hash. A `DeterministicSingleTimeSeries` shares the underlying
+`SingleTimeSeries` array and synthesizes its forecast windows on read.
 
-Each time series array is stored in an HDF5 group named with the array's UUID.
-Each group contains a dataset called `data` which contains the actual data.
-Each group also contains a group called `component_references` which contains
-an HDF5 attribute for each component reference. The component reference uses the
-format `<component_uuid>__<time_series_name>`.
+For the authoritative on-disk format — NetCDF dataset layout, hashing, the SQLite schema, and
+the `DATA_FORMAT_VERSION` compatibility contract — see the `time-series-store` repository's
+file-format reference.
 
-Each time series group defines attributes that control how the data will be
-deserialized into a `TimeSeriesData` instance.
+## Identifying and retrieving a time series
 
-  - `initial_timestamp`: Defines the first timestamp of the array. (All times are not stored.)
-  - `resolution`: Resolution of the time series in milliseconds.
-  - `type`: Type of the time series. Subtype of `TimeSeriesData`.
-  - `module`: Module that defines the type of the time series.
-  - `data_type`: Describes the type of the array stored.
+Address a stored time series by its [`TimeSeriesKey`](@ref) — a `StaticTimeSeriesKey` or
+`ForecastKey` — which captures `name`, `resolution`, `features`, and the concrete type
+(forecasts additionally capture `horizon`, `interval`, and `count`). Combined with the owner,
+this is the unique identity of an association:
 
-Example:
-
+```julia
+keys = get_time_series_keys(owner)      # enumerate the owner's associations
+ts = get_time_series(owner, keys[1])    # retrieve one by its key
 ```
-/time_series
-    data_format_version = "1.0.1"
-    compression_enabled = 1
-    /9f02f706-3394-4af3-8084-8903d302cbba
-        /component_references
-            0b6ecb61-8e8d-4563-b795-f001246c3ea5__max_active_power
-            613ddbc2-b666-4c9d-adb5-fa69e7f40a95__max_active_power
-        /data
-```
+
+> **Migration note.** The former `get_time_series_uuid` function and the `time_series_uuid`
+> metadata field have been removed. That UUID was derived from the array's content hash, so it
+> was *not* unique per association — two associations that happened to share identical data
+> shared a single UUID, making it unsuitable as a handle. Use [`TimeSeriesKey`](@ref) (above)
+> to address a specific time series. If you need *data* identity ("is this the same underlying
+> array?"), that is the array's SHA-256 content hash held by the store.
 
 ## Debugging
 
-The HDF Group provides tools to inspect and manipulate files. Refer to their
-[website](https://support.hdfgroup.org/products/hdf5_tools/).
-
-`HDFView` is especially useful for viewing data. Note that using `h5ls` and
-`h5dump` in a terminal combined with UNIX tools like `grep` can sometimes be
-faster.
+Inspect the artifacts with standard NetCDF and SQLite tools. For example, `ncdump -h <path>.nc`
+shows the array layout and dimensions, and `sqlite3 <path>.sqlite` lets you query the
+association catalog directly.
 
 ## Maintenance
 
-If you delete time series arrays in your system you may notice that the actual
-size of the HDF5 does not decrease. The only way to recover this space is to
-build a new file with only the active objects. The HDF5 tools package provides
-the tool `h5repack` for this purpose.
-
-```console
-$ h5repack time_series.h5 new.h5
-$ mv new.h5 time_series.h5
-```
+NetCDF files cannot shrink in place: deleting time series frees logical slots for reuse but
+does not immediately reduce the file size. Recovering that space requires an explicit
+compaction — rebuilding the artifact with only the active arrays — which is provided by the
+`time-series-store` backend.

--- a/src/descriptors/structs.json
+++ b/src/descriptors/structs.json
@@ -29,11 +29,6 @@
           "comment": "number of forecast windows"
         },
         {
-          "name": "time_series_uuid",
-          "data_type": "UUIDs.UUID",
-          "comment": "reference to time series data"
-        },
-        {
           "name": "horizon",
           "data_type": "Dates.Period",
           "comment": "length of this time series"
@@ -91,11 +86,6 @@
           "comment": "Percentiles for the probabilistic forecast"
         },
         {
-          "name": "time_series_uuid",
-          "data_type": "UUIDs.UUID",
-          "comment": "reference to time series data"
-        },
-        {
           "name": "horizon",
           "data_type": "Dates.Period",
           "comment": "length of this time series"
@@ -148,11 +138,6 @@
           "comment": "number of forecast windows"
         },
         {
-          "name": "time_series_uuid",
-          "data_type": "UUIDs.UUID",
-          "comment": "reference to time series data"
-        },
-        {
           "name": "horizon",
           "data_type": "Dates.Period",
           "comment": "length of this time series"
@@ -188,11 +173,6 @@
           "name": "initial_timestamp",
           "data_type": "Dates.DateTime",
           "comment": "time series availability time"
-        },
-        {
-          "name": "time_series_uuid",
-          "data_type": "UUIDs.UUID",
-          "comment": "reference to time series data"
         },
         {
           "name": "length",

--- a/src/deterministic.jl
+++ b/src/deterministic.jl
@@ -183,7 +183,7 @@ function Deterministic(ts_metadata::DeterministicMetadata, data::SortedDict)
         resolution = get_resolution(ts_metadata),
         interval = get_interval(ts_metadata),
         data = data,
-        internal = InfrastructureSystemsInternal(get_time_series_uuid(ts_metadata)),
+        internal = InfrastructureSystemsInternal(),
     )
 end
 

--- a/src/deterministic_metadata.jl
+++ b/src/deterministic_metadata.jl
@@ -5,7 +5,6 @@ function DeterministicMetadata(ts::AbstractDeterministic; features...)
         get_initial_timestamp(ts),
         get_interval(ts),
         get_count(ts),
-        get_uuid(ts),
         get_horizon(ts),
         typeof(ts),
         Dict{String, Any}(string(k) => v for (k, v) in features),

--- a/src/generated/DeterministicMetadata.jl
+++ b/src/generated/DeterministicMetadata.jl
@@ -11,7 +11,6 @@ This file is auto-generated. Do not edit.
         initial_timestamp::Dates.DateTime
         interval::Dates.Period
         count::Int
-        time_series_uuid::UUIDs.UUID
         horizon::Dates.Period
         time_series_type::Type{<:AbstractDeterministic}
         features::Dict{String, Union{Bool, Int, String}}
@@ -26,7 +25,6 @@ A deterministic forecast for a particular data field in a Component.
 - `initial_timestamp::Dates.DateTime`: time series availability time
 - `interval::Dates.Period`: time step between forecast windows
 - `count::Int`: number of forecast windows
-- `time_series_uuid::UUIDs.UUID`: reference to time series data
 - `horizon::Dates.Period`: length of this time series
 - `time_series_type::Type{<:AbstractDeterministic}`: Type of the time series data associated with this metadata.
 - `features::Dict{String, Union{Bool, Int, String}}`: (default: `Dict{String, Any}()`) User-defined tags that differentiate multiple time series arrays that represent the same component attribute, such as different arrays for different scenarios or years.
@@ -42,8 +40,6 @@ mutable struct DeterministicMetadata <: ForecastMetadata
     interval::Dates.Period
     "number of forecast windows"
     count::Int
-    "reference to time series data"
-    time_series_uuid::UUIDs.UUID
     "length of this time series"
     horizon::Dates.Period
     "Type of the time series data associated with this metadata."
@@ -53,12 +49,12 @@ mutable struct DeterministicMetadata <: ForecastMetadata
     internal::InfrastructureSystemsInternal
 end
 
-function DeterministicMetadata(name, resolution, initial_timestamp, interval, count, time_series_uuid, horizon, time_series_type, features=Dict{String, Any}(), )
-    DeterministicMetadata(name, resolution, initial_timestamp, interval, count, time_series_uuid, horizon, time_series_type, features, InfrastructureSystemsInternal(), )
+function DeterministicMetadata(name, resolution, initial_timestamp, interval, count, horizon, time_series_type, features=Dict{String, Any}(), )
+    DeterministicMetadata(name, resolution, initial_timestamp, interval, count, horizon, time_series_type, features, InfrastructureSystemsInternal(), )
 end
 
-function DeterministicMetadata(; name, resolution, initial_timestamp, interval, count, time_series_uuid, horizon, time_series_type, features=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), )
-    DeterministicMetadata(name, resolution, initial_timestamp, interval, count, time_series_uuid, horizon, time_series_type, features, internal, )
+function DeterministicMetadata(; name, resolution, initial_timestamp, interval, count, horizon, time_series_type, features=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), )
+    DeterministicMetadata(name, resolution, initial_timestamp, interval, count, horizon, time_series_type, features, internal, )
 end
 
 """Get [`DeterministicMetadata`](@ref) `name`."""
@@ -71,8 +67,6 @@ get_initial_timestamp(value::DeterministicMetadata) = value.initial_timestamp
 get_interval(value::DeterministicMetadata) = value.interval
 """Get [`DeterministicMetadata`](@ref) `count`."""
 get_count(value::DeterministicMetadata) = value.count
-"""Get [`DeterministicMetadata`](@ref) `time_series_uuid`."""
-get_time_series_uuid(value::DeterministicMetadata) = value.time_series_uuid
 """Get [`DeterministicMetadata`](@ref) `horizon`."""
 get_horizon(value::DeterministicMetadata) = value.horizon
 """Get [`DeterministicMetadata`](@ref) `time_series_type`."""
@@ -92,8 +86,6 @@ set_initial_timestamp!(value::DeterministicMetadata, val) = value.initial_timest
 set_interval!(value::DeterministicMetadata, val) = value.interval = val
 """Set [`DeterministicMetadata`](@ref) `count`."""
 set_count!(value::DeterministicMetadata, val) = value.count = val
-"""Set [`DeterministicMetadata`](@ref) `time_series_uuid`."""
-set_time_series_uuid!(value::DeterministicMetadata, val) = value.time_series_uuid = val
 """Set [`DeterministicMetadata`](@ref) `horizon`."""
 set_horizon!(value::DeterministicMetadata, val) = value.horizon = val
 """Set [`DeterministicMetadata`](@ref) `time_series_type`."""

--- a/src/generated/ProbabilisticMetadata.jl
+++ b/src/generated/ProbabilisticMetadata.jl
@@ -12,7 +12,6 @@ This file is auto-generated. Do not edit.
         interval::Dates.Period
         count::Int
         percentiles::Vector{Float64}
-        time_series_uuid::UUIDs.UUID
         horizon::Dates.Period
         features::Dict{String, Union{Bool, Int, String}}
         internal::InfrastructureSystemsInternal
@@ -27,7 +26,6 @@ A Probabilistic forecast for a particular data field in a Component.
 - `interval::Dates.Period`: time step between forecast windows
 - `count::Int`: number of forecast windows
 - `percentiles::Vector{Float64}`: Percentiles for the probabilistic forecast
-- `time_series_uuid::UUIDs.UUID`: reference to time series data
 - `horizon::Dates.Period`: length of this time series
 - `features::Dict{String, Union{Bool, Int, String}}`: (default: `Dict{String, Any}()`) User-defined tags that differentiate multiple time series arrays that represent the same component attribute, such as different arrays for different scenarios or years.
 - `internal::InfrastructureSystemsInternal`:
@@ -44,8 +42,6 @@ mutable struct ProbabilisticMetadata <: ForecastMetadata
     count::Int
     "Percentiles for the probabilistic forecast"
     percentiles::Vector{Float64}
-    "reference to time series data"
-    time_series_uuid::UUIDs.UUID
     "length of this time series"
     horizon::Dates.Period
     "User-defined tags that differentiate multiple time series arrays that represent the same component attribute, such as different arrays for different scenarios or years."
@@ -53,12 +49,12 @@ mutable struct ProbabilisticMetadata <: ForecastMetadata
     internal::InfrastructureSystemsInternal
 end
 
-function ProbabilisticMetadata(name, initial_timestamp, resolution, interval, count, percentiles, time_series_uuid, horizon, features=Dict{String, Any}(), )
-    ProbabilisticMetadata(name, initial_timestamp, resolution, interval, count, percentiles, time_series_uuid, horizon, features, InfrastructureSystemsInternal(), )
+function ProbabilisticMetadata(name, initial_timestamp, resolution, interval, count, percentiles, horizon, features=Dict{String, Any}(), )
+    ProbabilisticMetadata(name, initial_timestamp, resolution, interval, count, percentiles, horizon, features, InfrastructureSystemsInternal(), )
 end
 
-function ProbabilisticMetadata(; name, initial_timestamp, resolution, interval, count, percentiles, time_series_uuid, horizon, features=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), )
-    ProbabilisticMetadata(name, initial_timestamp, resolution, interval, count, percentiles, time_series_uuid, horizon, features, internal, )
+function ProbabilisticMetadata(; name, initial_timestamp, resolution, interval, count, percentiles, horizon, features=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), )
+    ProbabilisticMetadata(name, initial_timestamp, resolution, interval, count, percentiles, horizon, features, internal, )
 end
 
 """Get [`ProbabilisticMetadata`](@ref) `name`."""
@@ -73,8 +69,6 @@ get_interval(value::ProbabilisticMetadata) = value.interval
 get_count(value::ProbabilisticMetadata) = value.count
 """Get [`ProbabilisticMetadata`](@ref) `percentiles`."""
 get_percentiles(value::ProbabilisticMetadata) = value.percentiles
-"""Get [`ProbabilisticMetadata`](@ref) `time_series_uuid`."""
-get_time_series_uuid(value::ProbabilisticMetadata) = value.time_series_uuid
 """Get [`ProbabilisticMetadata`](@ref) `horizon`."""
 get_horizon(value::ProbabilisticMetadata) = value.horizon
 """Get [`ProbabilisticMetadata`](@ref) `features`."""
@@ -94,8 +88,6 @@ set_interval!(value::ProbabilisticMetadata, val) = value.interval = val
 set_count!(value::ProbabilisticMetadata, val) = value.count = val
 """Set [`ProbabilisticMetadata`](@ref) `percentiles`."""
 set_percentiles!(value::ProbabilisticMetadata, val) = value.percentiles = val
-"""Set [`ProbabilisticMetadata`](@ref) `time_series_uuid`."""
-set_time_series_uuid!(value::ProbabilisticMetadata, val) = value.time_series_uuid = val
 """Set [`ProbabilisticMetadata`](@ref) `horizon`."""
 set_horizon!(value::ProbabilisticMetadata, val) = value.horizon = val
 """Set [`ProbabilisticMetadata`](@ref) `features`."""

--- a/src/generated/ScenariosMetadata.jl
+++ b/src/generated/ScenariosMetadata.jl
@@ -12,7 +12,6 @@ This file is auto-generated. Do not edit.
         interval::Dates.Period
         scenario_count::Int64
         count::Int
-        time_series_uuid::UUIDs.UUID
         horizon::Dates.Period
         features::Dict{String, Union{Bool, Int, String}}
         internal::InfrastructureSystemsInternal
@@ -27,7 +26,6 @@ A Discrete Scenario Based time series for a particular data field in a Component
 - `interval::Dates.Period`: time step between forecast windows
 - `scenario_count::Int64`: Number of scenarios
 - `count::Int`: number of forecast windows
-- `time_series_uuid::UUIDs.UUID`: reference to time series data
 - `horizon::Dates.Period`: length of this time series
 - `features::Dict{String, Union{Bool, Int, String}}`: (default: `Dict{String, Any}()`) User-defined tags that differentiate multiple time series arrays that represent the same component attribute, such as different arrays for different scenarios or years.
 - `internal::InfrastructureSystemsInternal`:
@@ -44,8 +42,6 @@ mutable struct ScenariosMetadata <: ForecastMetadata
     scenario_count::Int64
     "number of forecast windows"
     count::Int
-    "reference to time series data"
-    time_series_uuid::UUIDs.UUID
     "length of this time series"
     horizon::Dates.Period
     "User-defined tags that differentiate multiple time series arrays that represent the same component attribute, such as different arrays for different scenarios or years."
@@ -53,12 +49,12 @@ mutable struct ScenariosMetadata <: ForecastMetadata
     internal::InfrastructureSystemsInternal
 end
 
-function ScenariosMetadata(name, resolution, initial_timestamp, interval, scenario_count, count, time_series_uuid, horizon, features=Dict{String, Any}(), )
-    ScenariosMetadata(name, resolution, initial_timestamp, interval, scenario_count, count, time_series_uuid, horizon, features, InfrastructureSystemsInternal(), )
+function ScenariosMetadata(name, resolution, initial_timestamp, interval, scenario_count, count, horizon, features=Dict{String, Any}(), )
+    ScenariosMetadata(name, resolution, initial_timestamp, interval, scenario_count, count, horizon, features, InfrastructureSystemsInternal(), )
 end
 
-function ScenariosMetadata(; name, resolution, initial_timestamp, interval, scenario_count, count, time_series_uuid, horizon, features=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), )
-    ScenariosMetadata(name, resolution, initial_timestamp, interval, scenario_count, count, time_series_uuid, horizon, features, internal, )
+function ScenariosMetadata(; name, resolution, initial_timestamp, interval, scenario_count, count, horizon, features=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), )
+    ScenariosMetadata(name, resolution, initial_timestamp, interval, scenario_count, count, horizon, features, internal, )
 end
 
 """Get [`ScenariosMetadata`](@ref) `name`."""
@@ -73,8 +69,6 @@ get_interval(value::ScenariosMetadata) = value.interval
 get_scenario_count(value::ScenariosMetadata) = value.scenario_count
 """Get [`ScenariosMetadata`](@ref) `count`."""
 get_count(value::ScenariosMetadata) = value.count
-"""Get [`ScenariosMetadata`](@ref) `time_series_uuid`."""
-get_time_series_uuid(value::ScenariosMetadata) = value.time_series_uuid
 """Get [`ScenariosMetadata`](@ref) `horizon`."""
 get_horizon(value::ScenariosMetadata) = value.horizon
 """Get [`ScenariosMetadata`](@ref) `features`."""
@@ -94,8 +88,6 @@ set_interval!(value::ScenariosMetadata, val) = value.interval = val
 set_scenario_count!(value::ScenariosMetadata, val) = value.scenario_count = val
 """Set [`ScenariosMetadata`](@ref) `count`."""
 set_count!(value::ScenariosMetadata, val) = value.count = val
-"""Set [`ScenariosMetadata`](@ref) `time_series_uuid`."""
-set_time_series_uuid!(value::ScenariosMetadata, val) = value.time_series_uuid = val
 """Set [`ScenariosMetadata`](@ref) `horizon`."""
 set_horizon!(value::ScenariosMetadata, val) = value.horizon = val
 """Set [`ScenariosMetadata`](@ref) `features`."""

--- a/src/generated/SingleTimeSeriesMetadata.jl
+++ b/src/generated/SingleTimeSeriesMetadata.jl
@@ -9,7 +9,6 @@ This file is auto-generated. Do not edit.
         name::String
         resolution::Dates.Period
         initial_timestamp::Dates.DateTime
-        time_series_uuid::UUIDs.UUID
         length::Int
         features::Dict{String, Union{Bool, Int, String}}
         internal::InfrastructureSystemsInternal
@@ -21,7 +20,6 @@ A TimeSeries Data object in contigous form.
 - `name::String`: user-defined name
 - `resolution::Dates.Period`:
 - `initial_timestamp::Dates.DateTime`: time series availability time
-- `time_series_uuid::UUIDs.UUID`: reference to time series data
 - `length::Int`: length of this time series
 - `features::Dict{String, Union{Bool, Int, String}}`: (default: `Dict{String, Any}()`) User-defined tags that differentiate multiple time series arrays that represent the same component attribute, such as different arrays for different scenarios or years.
 - `internal::InfrastructureSystemsInternal`:
@@ -32,8 +30,6 @@ mutable struct SingleTimeSeriesMetadata <: StaticTimeSeriesMetadata
     resolution::Dates.Period
     "time series availability time"
     initial_timestamp::Dates.DateTime
-    "reference to time series data"
-    time_series_uuid::UUIDs.UUID
     "length of this time series"
     length::Int
     "User-defined tags that differentiate multiple time series arrays that represent the same component attribute, such as different arrays for different scenarios or years."
@@ -41,12 +37,12 @@ mutable struct SingleTimeSeriesMetadata <: StaticTimeSeriesMetadata
     internal::InfrastructureSystemsInternal
 end
 
-function SingleTimeSeriesMetadata(name, resolution, initial_timestamp, time_series_uuid, length, features=Dict{String, Any}(), )
-    SingleTimeSeriesMetadata(name, resolution, initial_timestamp, time_series_uuid, length, features, InfrastructureSystemsInternal(), )
+function SingleTimeSeriesMetadata(name, resolution, initial_timestamp, length, features=Dict{String, Any}(), )
+    SingleTimeSeriesMetadata(name, resolution, initial_timestamp, length, features, InfrastructureSystemsInternal(), )
 end
 
-function SingleTimeSeriesMetadata(; name, resolution, initial_timestamp, time_series_uuid, length, features=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), )
-    SingleTimeSeriesMetadata(name, resolution, initial_timestamp, time_series_uuid, length, features, internal, )
+function SingleTimeSeriesMetadata(; name, resolution, initial_timestamp, length, features=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), )
+    SingleTimeSeriesMetadata(name, resolution, initial_timestamp, length, features, internal, )
 end
 
 """Get [`SingleTimeSeriesMetadata`](@ref) `name`."""
@@ -55,8 +51,6 @@ get_name(value::SingleTimeSeriesMetadata) = value.name
 get_resolution(value::SingleTimeSeriesMetadata) = value.resolution
 """Get [`SingleTimeSeriesMetadata`](@ref) `initial_timestamp`."""
 get_initial_timestamp(value::SingleTimeSeriesMetadata) = value.initial_timestamp
-"""Get [`SingleTimeSeriesMetadata`](@ref) `time_series_uuid`."""
-get_time_series_uuid(value::SingleTimeSeriesMetadata) = value.time_series_uuid
 """Get [`SingleTimeSeriesMetadata`](@ref) `length`."""
 get_length(value::SingleTimeSeriesMetadata) = value.length
 """Get [`SingleTimeSeriesMetadata`](@ref) `features`."""
@@ -70,8 +64,6 @@ set_name!(value::SingleTimeSeriesMetadata, val) = value.name = val
 set_resolution!(value::SingleTimeSeriesMetadata, val) = value.resolution = val
 """Set [`SingleTimeSeriesMetadata`](@ref) `initial_timestamp`."""
 set_initial_timestamp!(value::SingleTimeSeriesMetadata, val) = value.initial_timestamp = val
-"""Set [`SingleTimeSeriesMetadata`](@ref) `time_series_uuid`."""
-set_time_series_uuid!(value::SingleTimeSeriesMetadata, val) = value.time_series_uuid = val
 """Set [`SingleTimeSeriesMetadata`](@ref) `length`."""
 set_length!(value::SingleTimeSeriesMetadata, val) = value.length = val
 """Set [`SingleTimeSeriesMetadata`](@ref) `features`."""

--- a/src/generated/includes.jl
+++ b/src/generated/includes.jl
@@ -14,7 +14,6 @@ export get_percentiles
 export get_resolution
 export get_scenario_count
 export get_time_series_type
-export get_time_series_uuid
 export set_count!
 export set_features!
 export set_horizon!
@@ -26,4 +25,3 @@ export set_percentiles!
 export set_resolution!
 export set_scenario_count!
 export set_time_series_type!
-export set_time_series_uuid!

--- a/src/probabilistic.jl
+++ b/src/probabilistic.jl
@@ -184,7 +184,7 @@ function Probabilistic(ts_metadata::ProbabilisticMetadata, data::SortedDict)
         resolution = get_resolution(ts_metadata),
         interval = get_interval(ts_metadata),
         data = data,
-        internal = InfrastructureSystemsInternal(get_time_series_uuid(ts_metadata)),
+        internal = InfrastructureSystemsInternal(),
     )
 end
 
@@ -230,7 +230,6 @@ function ProbabilisticMetadata(time_series::Probabilistic; features...)
         get_interval(time_series),
         get_count(time_series),
         get_percentiles(time_series),
-        get_uuid(time_series),
         get_horizon(time_series),
         Dict{String, Any}(string(k) => v for (k, v) in features),
     )

--- a/src/rust_time_series_store.jl
+++ b/src/rust_time_series_store.jl
@@ -5,7 +5,7 @@
 # The Rust store owns both: arrays land in a NetCDF4 `.nc` file (content-addressed
 # by SHA-256 hash) and metadata in a sibling `.sqlite` file. Time series *data*
 # identity is the array content hash, not a UUID. Persisting a system writes the
-# `.nc` + `.sqlite` pair directly; no HDF5 is involved.
+# `.nc` + `.sqlite` pair directly.
 #
 # This file holds the IS-specific glue (owner/feature conversion, window
 # flatten/reshape, manager routing). All low-level FFI lives in `TimeSeriesStore`.
@@ -100,7 +100,7 @@ close!(store::RustTimeSeriesStore) = TSS.close!(store.inner)
 
 # ---- Conversions -----------------------------------------------------------
 
-_tss_category(category::AbstractString) =
+_tss_category(category::String) =
     if category == "Component"
         TSS.Component
     elseif category == "SupplementalAttribute"
@@ -324,7 +324,6 @@ function get_single(
         data = TimeSeries.TimeArray(collect(timestamps), values),
         resolution = meta.resolution,
     )
-    set_uuid!(get_internal(sts), _rust_ts_uuid(meta.data_hash))
     return sts
 end
 
@@ -401,20 +400,10 @@ _rust_row_identity(row) = (
 # Counts of SingleTimeSeries and DeterministicSingleTimeSeries associations that
 # reference the given content hash, across all owners. Used to decide whether a
 # SingleTimeSeries can be removed without orphaning a DST that shares its array.
-function _rust_array_sts_dst_counts(store::RustTimeSeriesStore, hash::Vector{UInt8})
-    sts = 0
-    dst = 0
-    for row in TSS.list_metadata(store.inner)
-        row.data_hash == hash || continue
-        t = _rust_is_type(row.time_series_type)
-        if t <: DeterministicSingleTimeSeries
-            dst += 1
-        elseif t <: SingleTimeSeries
-            sts += 1
-        end
-    end
-    return (sts = sts, dst = dst)
-end
+# Resolved by a single catalog query in the Rust core rather than scanning every
+# association here.
+_rust_array_sts_dst_counts(store::RustTimeSeriesStore, hash::Vector{UInt8}) =
+    TSS.count_array_references(store.inner, hash)
 
 # Remove the single association described by a `TSS.list_metadata` row.
 function _rust_remove_row!(store::RustTimeSeriesStore, row)
@@ -486,8 +475,6 @@ function _rust_add_time_series!(
 
     serialize_single!(store, owner_id, owner_type, owner_category, name, time_series;
         features = feats)
-    _rust_assign_stored_uuid!(store, time_series, owner_id, category, name,
-        TSS.TS_TYPE_SINGLE; resolution = resolution, features = feats)
     return StaticTimeSeriesKey(;
         time_series_type = SingleTimeSeries,
         name = name,
@@ -573,7 +560,6 @@ function _rust_get_time_series(
         data = TimeSeries.TimeArray(collect(timestamps), vals),
         resolution = meta.resolution,
     )
-    set_uuid!(get_internal(sts), _rust_ts_uuid(meta.data_hash))
     return sts
 end
 
@@ -624,8 +610,6 @@ function _rust_add_forecast!(mgr::TimeSeriesManager, owner, ts; features...)
             interval, get_count(ts), Float64.(get_percentiles(ts)), arr, name)
         TSS.add_time_series!(store.inner, owner_id, owner_type,
             category, prob; features = feats)
-        _rust_assign_stored_uuid!(store, ts, owner_id, category, name,
-            TSS.TS_TYPE_PROBABILISTIC; resolution = resolution, features = feats)
         return ForecastKey(;
             time_series_type = typeof(ts), name = name,
             initial_timestamp = get_initial_timestamp(ts), resolution = resolution,
@@ -702,8 +686,6 @@ function _rust_add_forecast!(mgr::TimeSeriesManager, owner, ts; features...)
     end
     TSS.add_time_series!(store.inner, owner_id, owner_type,
         category, tss_ts; features = feats)
-    _rust_assign_stored_uuid!(store, ts, owner_id, category, name, ts_type;
-        resolution = resolution, features = feats)
     return ForecastKey(;
         time_series_type = typeof(ts), name = name,
         initial_timestamp = get_initial_timestamp(ts), resolution = resolution,
@@ -789,9 +771,6 @@ function _rust_get_forecast(
         result = Probabilistic(; name = String(name), data = data,
             percentiles = p.percentiles, resolution = p.resolution,
             interval = p.interval)
-        _rust_assign_stored_uuid!(store, result, owner_id, category, name,
-            TSS.TS_TYPE_PROBABILISTIC;
-            resolution = resolution, features = feats)
         return result
     elseif has_typed(store, owner_id, category, name, TSS.TS_TYPE_DETERMINISTIC;
         resolution = resolution, features = feats)
@@ -821,7 +800,6 @@ function _rust_get_forecast(
         )
         result = Deterministic(; name = String(name), data = data,
             resolution = d.resolution, interval = d.interval)
-        set_uuid!(get_internal(result), _rust_ts_uuid(fmeta.data_hash))
         return result
     elseif has_typed(store, owner_id, category, name, TSS.TS_TYPE_DETERMINISTIC_SINGLE;
         resolution = resolution, features = feats)
@@ -872,9 +850,6 @@ function _rust_get_forecast(
         result = Scenarios(; name = String(name), data = data,
             scenario_count = s_ts.scenario_count,
             resolution = s_ts.resolution, interval = s_ts.interval)
-        _rust_assign_stored_uuid!(store, result, owner_id, category, name,
-            TSS.TS_TYPE_SCENARIOS;
-            resolution = resolution, features = feats)
         return result
     end
     throw(RustTimeSeriesNotFound("no forecast for owner=$owner_id name=$name"))
@@ -931,53 +906,6 @@ function _rust_has_any(owner; time_series_type::Union{Nothing, Type} = nothing)
 end
 
 # ---- Metadata reconstruction (parity with the SQLite metadata store) --------
-#
-# The Rust store is content-addressed: a time series' identity is the SHA-256
-# hash of its array, not a per-association UUID. IS still exposes
-# `time_series_uuid`, so we derive a stable `Base.UUID` from the hash. A UUID is
-# 16 bytes, so we use the hash's 16-byte prefix; identical arrays therefore share
-# a UUID, consistent with the store's content-addressed de-duplication.
-function _rust_ts_uuid(hash::Vector{UInt8})
-    length(hash) >= 16 ||
-        error("Rust data hash too short to derive a UUID: $(length(hash))")
-    u = UInt128(0)
-    @inbounds for i in 1:16
-        u = (u << 8) | hash[i]
-    end
-    return Base.UUID(u)
-end
-
-# Give a just-stored time series object the content-addressed identity used on
-# reconstruction (UUID derived from the array hash), so `get_uuid(original)`
-# matches `get_uuid(get_time_series(...))`.
-function _rust_assign_stored_uuid!(
-    store::RustTimeSeriesStore,
-    ts::TimeSeriesData,
-    owner_id::Integer,
-    owner_category::TSS.OwnerCategory,
-    name::AbstractString,
-    ts_type_code::Integer;
-    resolution = nothing,
-    features = Dict{String, Any}(),
-)
-    hash = if ts_type_code in (TSS.TS_TYPE_SINGLE, TSS.TS_TYPE_DETERMINISTIC_SINGLE)
-        # A DST shares its underlying SingleTimeSeries array; use that hash.
-        get_metadata(
-            store,
-            owner_id,
-            owner_category,
-            name;
-            resolution = resolution,
-            features = features,
-        ).data_hash
-    else
-        TSS.get_forecast_metadata(store.inner, owner_id, owner_category, name, ts_type_code;
-            resolution = resolution, features = features).data_hash
-    end
-    set_uuid!(get_internal(ts), _rust_ts_uuid(hash))
-    return
-end
-
 # IS time series type for a `TimeSeriesStore` metadata-row type (matched by name).
 _rust_is_type(t::Type) = _rust_is_type(nameof(t))
 _rust_is_type(s::Symbol) =
@@ -1011,14 +939,12 @@ _rust_type_matches(row_type::Type, ::Type{T}) where {T <: TimeSeriesData} =
 # Build the matching IS `TimeSeriesMetadata` from a `TSS.list_metadata` row.
 function _metadata_from_row(row)
     feats = Dict{String, Union{Bool, Int, String}}(row.features)
-    uuid = _rust_ts_uuid(row.data_hash)
     is_type = _rust_is_type(row.time_series_type)
     if is_type <: SingleTimeSeries
         return SingleTimeSeriesMetadata(;
             name = row.name,
             resolution = row.resolution,
             initial_timestamp = row.initial_timestamp,
-            time_series_uuid = uuid,
             length = row.length,
             features = feats,
         )
@@ -1029,7 +955,6 @@ function _metadata_from_row(row)
             initial_timestamp = row.initial_timestamp,
             interval = row.interval,
             count = row.count,
-            time_series_uuid = uuid,
             horizon = row.horizon,
             time_series_type = is_type,
             features = feats,
@@ -1042,7 +967,6 @@ function _metadata_from_row(row)
             interval = row.interval,
             count = row.count,
             percentiles = row.percentiles,
-            time_series_uuid = uuid,
             horizon = row.horizon,
             features = feats,
         )
@@ -1056,7 +980,6 @@ function _metadata_from_row(row)
             interval = row.interval,
             scenario_count = row.length,
             count = row.count,
-            time_series_uuid = uuid,
             horizon = row.horizon,
             features = feats,
         )

--- a/src/scenarios.jl
+++ b/src/scenarios.jl
@@ -171,7 +171,7 @@ function Scenarios(ts_metadata::ScenariosMetadata, data::SortedDict)
         resolution = get_resolution(ts_metadata),
         interval = get_interval(ts_metadata),
         data = data,
-        internal = InfrastructureSystemsInternal(get_time_series_uuid(ts_metadata)),
+        internal = InfrastructureSystemsInternal(),
     )
 end
 
@@ -194,7 +194,6 @@ function ScenariosMetadata(time_series::Scenarios; features...)
         get_interval(time_series),
         get_scenario_count(time_series),
         get_count(time_series),
-        get_uuid(time_series),
         get_horizon(time_series),
         Dict{String, Any}(string(k) => v for (k, v) in features),
     )

--- a/src/single_time_series.jl
+++ b/src/single_time_series.jl
@@ -203,7 +203,7 @@ function SingleTimeSeries(ts_metadata::SingleTimeSeriesMetadata, data::TimeSerie
         get_name(ts_metadata),
         data,
         get_resolution(ts_metadata),
-        InfrastructureSystemsInternal(get_time_series_uuid(ts_metadata)),
+        InfrastructureSystemsInternal(),
     )
 end
 
@@ -219,7 +219,6 @@ function SingleTimeSeriesMetadata(ts::SingleTimeSeries; features...)
         get_name(ts),
         get_resolution(ts),
         get_initial_timestamp(ts),
-        get_uuid(ts),
         length(ts),
         Dict{String, Any}(string(k) => v for (k, v) in features),
     )
@@ -405,7 +404,6 @@ function SingleTimeSeriesMetadata(ts_metadata::DeterministicMetadata)
         name = get_name(ts_metadata),
         resolution = get_resolution(ts_metadata),
         initial_timestamp = get_initial_timestamp(ts_metadata),
-        time_series_uuid = get_time_series_uuid(ts_metadata),
         length = get_count(ts_metadata) * get_horizon_count(ts_metadata),
         internal = get_internal(ts_metadata),
     )

--- a/src/supplemental_attribute_associations.jl
+++ b/src/supplemental_attribute_associations.jl
@@ -1,25 +1,17 @@
 const SUPPLEMENTAL_ATTRIBUTE_TABLE_NAME = "supplemental_attributes"
 
 # Design note:
-# Supplemental attributes and time series are stored in independent SQLite databases.
-# Ideally, they would be different tables in the same database. This is not practical
-# because of requirements set by the team for serialization output files.
+# Supplemental attribute associations are kept in their own in-memory SQLite database,
+# separate from time series storage.
 #
 # Background:
-#   - Time series metadata is always persisted as a SQLite file during serialization.
-#   - That SQLite file is written as an HDF5 dataset in the time series data file.
-#   - The result of serialization is system.json, system_metadata.json, and
-#     system_time_series.h5.
-#   - If there is no time series in the system, then there is no extra file: only
-#     system.json and system_metadata.json.
+#   - Time series data and its association catalog are persisted by the `time-series-store`
+#     Rust backend as a `<path>.nc` / `<path>.sqlite` pair, independent of this database.
+#   - Supplemental attribute associations are never persisted as a database file; they are
+#     serialized into the system JSON instead, so a system with supplemental attributes but
+#     no time series produces no extra storage artifact.
 #
-# If we persist supplemental attribute associations to a SQLite file and there is no time
-# series, serialization would produce an extra file. The team was strongly opposed to this
-# and set a requirement that those associations must be written to the system JSON file.
-#
-# Rather than try to manage the complexities of temporarily sharing a database across
-# serialization and deepcopy operations, this design keeps them separate in order to
-# simplifiy the code. The supplemental attribute database is always ephemeral.
+# This database is therefore always ephemeral (in-memory only).
 
 mutable struct SupplementalAttributeAssociations
     db::SQLite.DB

--- a/src/time_series_interface.jl
+++ b/src/time_series_interface.jl
@@ -170,23 +170,6 @@ function get_time_series_multiple(
     )
 end
 
-function get_time_series_uuid(
-    ::Type{T},
-    component::InfrastructureSystemsComponent,
-    name::AbstractString;
-    resolution::Union{Nothing, Dates.Period} = nothing,
-    interval::Union{Nothing, Dates.Period} = nothing,
-) where {T <: TimeSeriesData}
-    metadata = get_time_series_metadata(
-        T,
-        component,
-        name;
-        resolution = resolution,
-        interval = interval,
-    )
-    return get_time_series_uuid(metadata)
-end
-
 function get_time_series_metadata(
     ::Type{T},
     owner::TimeSeriesOwners,

--- a/test/test_time_series.jl
+++ b/test/test_time_series.jl
@@ -80,9 +80,6 @@
         end
     end
     @test found == count
-
-    @test IS.get_uuid(forecast) == IS.get_uuid(var1)
-    @test IS.get_uuid(forecast) == IS.get_uuid(var2)
 end
 
 @testset "Test add Deterministic" begin
@@ -3099,56 +3096,6 @@ end
     counts = IS.get_time_series_counts(sys)
     @test counts.static_time_series_count == 1
     @test counts.components_with_time_series == 2
-end
-
-@testset "Test get_time_series_uuid" begin
-    sys = IS.SystemData()
-    name = "Component1"
-    component = IS.TestComponent(name, 5)
-    IS.add_component!(sys, component)
-
-    initial_time = Dates.DateTime("2020-09-01")
-    resolution = Dates.Hour(1)
-
-    data = TimeSeries.TimeArray(
-        range(initial_time; length = 365, step = resolution),
-        rand(365),
-    )
-    ts_name = "test"
-    ts = IS.SingleTimeSeries(; data = data, name = ts_name)
-    IS.add_time_series!(sys, component, ts)
-    # The Rust backend is content-addressed: storing a time series gives it (and
-    # its object) the content-derived UUID, so capture it after the add.
-    uuid = IS.get_uuid(ts)
-    @test IS.get_time_series_uuid(IS.SingleTimeSeries, component, ts_name) == uuid
-end
-
-@testset "Test get_time_series_uuid with multiple resolutions" begin
-    params = setup_for_multi_resolution_tests()
-    component = params.component
-    sts_name = params.sts_name
-    resolution1 = params.resolution1
-    resolution2 = params.resolution2
-    uuid1 = IS.get_uuid(params.sts1)
-    uuid2 = IS.get_uuid(params.sts2)
-
-    @test IS.get_time_series_uuid(
-        IS.SingleTimeSeries,
-        component,
-        sts_name;
-        resolution = resolution1,
-    ) == uuid1
-    @test IS.get_time_series_uuid(
-        IS.SingleTimeSeries,
-        component,
-        sts_name;
-        resolution = resolution2,
-    ) == uuid2
-    @test_throws ArgumentError IS.get_time_series_uuid(
-        IS.SingleTimeSeries,
-        component,
-        sts_name,
-    )
 end
 
 @testset "Test serialization of time series keys" begin


### PR DESCRIPTION
- Route AbstractDeterministic reads through the family-resolving TimeSeriesStore API, and delegate array reference-counting to the core (count_array_references) instead of scanning metadata in Julia.
- Remove the vestigial time-series UUID end to end: drop time_series_uuid from structs.json and the 4 generated metadata structs, the public get_time_series_uuid API and exports, and the _rust_ts_uuid / _rust_assign_stored_uuid! shim with all set_uuid! / _metadata_from_row sites. The Rust store is content-addressed; address a time series via TimeSeriesKey (the old UUID was hash-derived and not unique per association, so it was unsuitable as a handle).
- docs: rewrite the stale HDF5 storage docs to describe the Rust NetCDF + SQLite content-addressed store; correct the supplemental attribute schema to integer IDs; refresh a stale design comment.

Validated: IS.jl precompiles and the time-series test suite passes (4733 assertions, 0 failures, 3 pre-existing broken).

BREAKING: removes the public get_time_series_uuid API and the time_series_uuid serialization field; needs PowerSystems.jl coordination.